### PR TITLE
feat: backfill product classification (maintenance task)

### DIFF
--- a/Application/Frigorino.Infrastructure/Services/MaintenanceDependencyInjection.cs
+++ b/Application/Frigorino.Infrastructure/Services/MaintenanceDependencyInjection.cs
@@ -1,14 +1,26 @@
 using Frigorino.Domain.Interfaces;
 using Frigorino.Infrastructure.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Frigorino.Infrastructure.Services
 {
     public static class MaintenanceDependencyInjection
     {
-        public static IServiceCollection AddMaintenanceServices(this IServiceCollection services)
+        public static IServiceCollection AddMaintenanceServices(
+            this IServiceCollection services, IConfiguration configuration)
         {
             services.AddScoped<IMaintenanceTask, DeleteInactiveItems>();
+
+            // Registered only when live classification is on (same condition as
+            // ItemClassificationDependencyInjection); otherwise IItemClassifier and the queueing
+            // trigger are not in the container and ValidateOnBuild would fail.
+            var classificationEnabled = configuration.GetValue<bool>("Ai:Classifier:Enabled");
+            var apiKey = configuration["Ai:ApiKey"];
+            if (classificationEnabled && !string.IsNullOrWhiteSpace(apiKey))
+            {
+                services.AddScoped<IMaintenanceTask, BackfillProductClassification>();
+            }
 
             services.AddHostedService<MaintenanceHostedService>();
 

--- a/Application/Frigorino.Infrastructure/Tasks/BackfillProductClassification.cs
+++ b/Application/Frigorino.Infrastructure/Tasks/BackfillProductClassification.cs
@@ -32,7 +32,7 @@ namespace Frigorino.Infrastructure.Tasks
         public async Task Run(CancellationToken cancellationToken = default)
         {
             var candidates = await _dbContext.ListItems
-                .Where(li => li.IsActive)
+                .Where(li => li.IsActive && li.List.IsActive)
                 .Select(li => new ListItemNameCandidate(li.List.HouseholdId, li.Text))
                 .Distinct()
                 .ToListAsync(cancellationToken);

--- a/Application/Frigorino.Infrastructure/Tasks/BackfillProductClassification.cs
+++ b/Application/Frigorino.Infrastructure/Tasks/BackfillProductClassification.cs
@@ -1,0 +1,64 @@
+using Frigorino.Domain.Interfaces;
+using Frigorino.Infrastructure.EntityFramework;
+using Frigorino.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Frigorino.Infrastructure.Tasks
+{
+    // Startup backfill: enqueue classification for ListItem product names that have no up-to-date
+    // Product (never classified, or below the current ClassifierVersion). Idempotent and
+    // version-aware via the existing classify job; capped per run, with the remainder picked up on
+    // the next cold start (the queue is lossy, but loss here is recoverable by re-scanning).
+    public class BackfillProductClassification : IMaintenanceTask
+    {
+        private readonly ApplicationDbContext _dbContext;
+        private readonly IProductClassificationTrigger _trigger;
+        private readonly IItemClassifier _classifier;
+        private readonly ILogger<BackfillProductClassification> _logger;
+
+        public BackfillProductClassification(
+            ApplicationDbContext dbContext,
+            IProductClassificationTrigger trigger,
+            IItemClassifier classifier,
+            ILogger<BackfillProductClassification> logger)
+        {
+            _dbContext = dbContext;
+            _trigger = trigger;
+            _classifier = classifier;
+            _logger = logger;
+        }
+
+        public async Task Run(CancellationToken cancellationToken = default)
+        {
+            var candidates = await _dbContext.ListItems
+                .Where(li => li.IsActive)
+                .Select(li => new ListItemNameCandidate(li.List.HouseholdId, li.Text))
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            var existing = await _dbContext.Products
+                .Select(p => new ExistingProduct(p.HouseholdId, p.NormalizedName, p.ClassifierVersion))
+                .ToListAsync(cancellationToken);
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, _classifier.Version);
+            if (gaps.Count == 0)
+            {
+                return;
+            }
+
+            // Cap per run to the queue capacity so a large first backfill cannot overflow (and
+            // silently drop) the lossy queue; the remainder is enqueued on the next cold start.
+            var toEnqueue = gaps.Take(BackgroundTaskQueue.Capacity).ToList();
+            foreach (var gap in toEnqueue)
+            {
+                _trigger.OnProductReferenced(gap.HouseholdId, gap.RawName);
+            }
+
+            var deferred = gaps.Count - toEnqueue.Count;
+            _logger.LogInformation(
+                "Backfill classification: {Total} gap(s) found, {Enqueued} enqueued, {Deferred} deferred to next cold start.",
+                gaps.Count, toEnqueue.Count, deferred);
+        }
+    }
+}

--- a/Application/Frigorino.Infrastructure/Tasks/ProductClassificationGaps.cs
+++ b/Application/Frigorino.Infrastructure/Tasks/ProductClassificationGaps.cs
@@ -1,0 +1,65 @@
+using Frigorino.Domain.Products;
+
+namespace Frigorino.Infrastructure.Tasks
+{
+    // A distinct product name referenced by an active ListItem, tagged with its household
+    // (resolved via ListItem -> List -> HouseholdId). RawText is normalized by the helper.
+    public sealed record ListItemNameCandidate(int HouseholdId, string RawText);
+
+    // An existing product catalog row, reduced to the fields needed to decide staleness.
+    public sealed record ExistingProduct(int HouseholdId, string NormalizedName, int ClassifierVersion);
+
+    // A name needing (re)classification, carrying one representative raw name so the trigger/job
+    // normalizes it consistently with the live path.
+    public sealed record ClassificationGap(int HouseholdId, string RawName);
+
+    // Pure gap decision: which referenced names have no up-to-date Product (never classified, or
+    // below the current classifier version). Kept free of EF so it is unit-testable without a
+    // database (mirrors CheckedItemPurge).
+    public static class ProductClassificationGaps
+    {
+        public static List<ClassificationGap> SelectGaps(
+            IReadOnlyCollection<ListItemNameCandidate> candidates,
+            IReadOnlyCollection<ExistingProduct> existingProducts,
+            int currentClassifierVersion)
+        {
+            // Highest classifier version per (household, normalized name). The unique index makes
+            // duplicates unlikely, but Max keeps the decision well-defined regardless.
+            var versionByName = new Dictionary<(int Household, string Name), int>();
+            foreach (var product in existingProducts)
+            {
+                var key = (product.HouseholdId, product.NormalizedName);
+                if (!versionByName.TryGetValue(key, out var current) || product.ClassifierVersion > current)
+                {
+                    versionByName[key] = product.ClassifierVersion;
+                }
+            }
+
+            var gaps = new List<ClassificationGap>();
+            var seen = new HashSet<(int Household, string Name)>();
+            foreach (var candidate in candidates)
+            {
+                var normalized = ProductName.Normalize(candidate.RawText);
+                if (normalized.Length == 0)
+                {
+                    continue;
+                }
+
+                var key = (candidate.HouseholdId, normalized);
+                if (!seen.Add(key))
+                {
+                    continue;
+                }
+
+                var isUpToDate = versionByName.TryGetValue(key, out var version)
+                    && version >= currentClassifierVersion;
+                if (!isUpToDate)
+                {
+                    gaps.Add(new ClassificationGap(candidate.HouseholdId, candidate.RawText));
+                }
+            }
+
+            return gaps;
+        }
+    }
+}

--- a/Application/Frigorino.Test/Infrastructure/ProductClassificationGapsTests.cs
+++ b/Application/Frigorino.Test/Infrastructure/ProductClassificationGapsTests.cs
@@ -1,0 +1,89 @@
+using Frigorino.Infrastructure.Tasks;
+
+namespace Frigorino.Test.Infrastructure
+{
+    public class ProductClassificationGapsTests
+    {
+        private const int CurrentVersion = 2;
+
+        [Fact]
+        public void NeverClassifiedName_IsGap()
+        {
+            var candidates = new[] { new ListItemNameCandidate(HouseholdId: 10, RawText: "Milk") };
+            var existing = Array.Empty<ExistingProduct>();
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Equal(new[] { new ClassificationGap(10, "Milk") }, gaps);
+        }
+
+        [Fact]
+        public void UpToDateProduct_IsSkipped()
+        {
+            var candidates = new[] { new ListItemNameCandidate(10, "Milk") };
+            var existing = new[] { new ExistingProduct(10, "milk", ClassifierVersion: CurrentVersion) };
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Empty(gaps);
+        }
+
+        [Fact]
+        public void StaleVersionProduct_IsGap()
+        {
+            var candidates = new[] { new ListItemNameCandidate(10, "Milk") };
+            var existing = new[] { new ExistingProduct(10, "milk", ClassifierVersion: CurrentVersion - 1) };
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Equal(new[] { new ClassificationGap(10, "Milk") }, gaps);
+        }
+
+        [Fact]
+        public void MultipleSpellings_NormalizeToSingleGap()
+        {
+            var candidates = new[]
+            {
+                new ListItemNameCandidate(10, "Milk"),
+                new ListItemNameCandidate(10, "  milk "),
+                new ListItemNameCandidate(10, "MILK"),
+            };
+            var existing = Array.Empty<ExistingProduct>();
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Single(gaps);
+            Assert.Equal(10, gaps[0].HouseholdId);
+        }
+
+        [Fact]
+        public void SameNameDifferentHouseholds_AreIndependentGaps()
+        {
+            var candidates = new[]
+            {
+                new ListItemNameCandidate(10, "Milk"),
+                new ListItemNameCandidate(20, "Milk"),
+            };
+            var existing = new[] { new ExistingProduct(10, "milk", CurrentVersion) };
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Equal(new[] { new ClassificationGap(20, "Milk") }, gaps);
+        }
+
+        [Fact]
+        public void BlankText_IsSkipped()
+        {
+            var candidates = new[]
+            {
+                new ListItemNameCandidate(10, "   "),
+                new ListItemNameCandidate(10, ""),
+            };
+            var existing = Array.Empty<ExistingProduct>();
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Empty(gaps);
+        }
+    }
+}

--- a/Application/Frigorino.Test/Infrastructure/ProductClassificationGapsTests.cs
+++ b/Application/Frigorino.Test/Infrastructure/ProductClassificationGapsTests.cs
@@ -72,6 +72,23 @@ namespace Frigorino.Test.Infrastructure
         }
 
         [Fact]
+        public void HighestProductVersionWins_WhenDuplicateRowsExist()
+        {
+            var candidates = new[] { new ListItemNameCandidate(10, "Milk") };
+            // Duplicate rows for the same (household, name): one stale, one current. The current
+            // one must win so the name is considered up-to-date and skipped.
+            var existing = new[]
+            {
+                new ExistingProduct(10, "milk", ClassifierVersion: CurrentVersion - 1),
+                new ExistingProduct(10, "milk", ClassifierVersion: CurrentVersion),
+            };
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Empty(gaps);
+        }
+
+        [Fact]
         public void BlankText_IsSkipped()
         {
             var candidates = new[]

--- a/Application/Frigorino.Web/Program.cs
+++ b/Application/Frigorino.Web/Program.cs
@@ -82,7 +82,7 @@ builder.Services.TryAddScoped<INotificationSender, LogOnlyNotificationSender>();
 builder.Services.AddBackgroundTaskQueue();
 builder.Services.AddItemClassification(builder.Configuration);
 builder.Services.AddQuantityExtraction(builder.Configuration);
-builder.Services.AddMaintenanceServices();
+builder.Services.AddMaintenanceServices(builder.Configuration);
 builder.Services.AddExpiryNotifications(builder.Configuration);
 
 if (!isBuildTimeOpenApi)

--- a/docs/superpowers/plans/2026-06-02-backfill-product-classification.md
+++ b/docs/superpowers/plans/2026-06-02-backfill-product-classification.md
@@ -1,0 +1,410 @@
+# Backfill Product Classification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a startup maintenance task that backfills AI classification for existing ListItem product names that have no up-to-date `Product`.
+
+**Architecture:** A pure, unit-tested helper (`ProductClassificationGaps`) decides which distinct normalized names referenced by active ListItems lack an up-to-date `Product` (never classified, or below the current `ClassifierVersion`). A thin `IMaintenanceTask` (`BackfillProductClassification`) loads the data, runs the helper, and enqueues each gap through the existing `IProductClassificationTrigger` (the live classification path). Registration is gated on the same `Ai:Classifier:Enabled` + API-key condition as live classification, so it is wired only when classification is actually on.
+
+**Tech Stack:** .NET 10, EF Core (Postgres), xUnit. Reuses existing `BackgroundTaskQueue` / `QueuedHostedService` / `ClassifyProductJob` infrastructure.
+
+---
+
+## File Structure
+
+- **Create** `Application/Frigorino.Infrastructure/Tasks/ProductClassificationGaps.cs` — pure gap-selection helper + its input/output records. Mirrors `CheckedItemPurge.cs` (same folder, EF-free so it is unit-testable).
+- **Create** `Application/Frigorino.Test/Infrastructure/ProductClassificationGapsTests.cs` — unit tests for the helper. Mirrors `CheckedItemPurgeTests.cs`.
+- **Create** `Application/Frigorino.Infrastructure/Tasks/BackfillProductClassification.cs` — the `IMaintenanceTask`. Thin orchestration (load → helper → enqueue → log).
+- **Modify** `Application/Frigorino.Infrastructure/Services/MaintenanceDependencyInjection.cs` — add `IConfiguration` param; register the task only when classification is enabled.
+- **Modify** `Application/Frigorino.Web/Program.cs:85` — pass `builder.Configuration` into `AddMaintenanceServices`.
+
+---
+
+## Task 1: Pure gap-selection helper
+
+**Files:**
+- Create: `Application/Frigorino.Infrastructure/Tasks/ProductClassificationGaps.cs`
+- Test: `Application/Frigorino.Test/Infrastructure/ProductClassificationGapsTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Application/Frigorino.Test/Infrastructure/ProductClassificationGapsTests.cs`:
+
+```csharp
+using Frigorino.Infrastructure.Tasks;
+
+namespace Frigorino.Test.Infrastructure
+{
+    public class ProductClassificationGapsTests
+    {
+        private const int CurrentVersion = 2;
+
+        [Fact]
+        public void NeverClassifiedName_IsGap()
+        {
+            var candidates = new[] { new ListItemNameCandidate(HouseholdId: 10, RawText: "Milk") };
+            var existing = Array.Empty<ExistingProduct>();
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Equal(new[] { new ClassificationGap(10, "Milk") }, gaps);
+        }
+
+        [Fact]
+        public void UpToDateProduct_IsSkipped()
+        {
+            var candidates = new[] { new ListItemNameCandidate(10, "Milk") };
+            var existing = new[] { new ExistingProduct(10, "milk", ClassifierVersion: CurrentVersion) };
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Empty(gaps);
+        }
+
+        [Fact]
+        public void StaleVersionProduct_IsGap()
+        {
+            var candidates = new[] { new ListItemNameCandidate(10, "Milk") };
+            var existing = new[] { new ExistingProduct(10, "milk", ClassifierVersion: CurrentVersion - 1) };
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Equal(new[] { new ClassificationGap(10, "Milk") }, gaps);
+        }
+
+        [Fact]
+        public void MultipleSpellings_NormalizeToSingleGap()
+        {
+            var candidates = new[]
+            {
+                new ListItemNameCandidate(10, "Milk"),
+                new ListItemNameCandidate(10, "  milk "),
+                new ListItemNameCandidate(10, "MILK"),
+            };
+            var existing = Array.Empty<ExistingProduct>();
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Single(gaps);
+            Assert.Equal(10, gaps[0].HouseholdId);
+        }
+
+        [Fact]
+        public void SameNameDifferentHouseholds_AreIndependentGaps()
+        {
+            var candidates = new[]
+            {
+                new ListItemNameCandidate(10, "Milk"),
+                new ListItemNameCandidate(20, "Milk"),
+            };
+            var existing = new[] { new ExistingProduct(10, "milk", CurrentVersion) };
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Equal(new[] { new ClassificationGap(20, "Milk") }, gaps);
+        }
+
+        [Fact]
+        public void BlankText_IsSkipped()
+        {
+            var candidates = new[]
+            {
+                new ListItemNameCandidate(10, "   "),
+                new ListItemNameCandidate(10, ""),
+            };
+            var existing = Array.Empty<ExistingProduct>();
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, CurrentVersion);
+
+            Assert.Empty(gaps);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test Application/Frigorino.Test --filter "FullyQualifiedName~ProductClassificationGapsTests"`
+Expected: FAIL — does not compile (`ProductClassificationGaps`, `ListItemNameCandidate`, `ExistingProduct`, `ClassificationGap` do not exist).
+
+- [ ] **Step 3: Write the helper**
+
+Create `Application/Frigorino.Infrastructure/Tasks/ProductClassificationGaps.cs`:
+
+```csharp
+using Frigorino.Domain.Products;
+
+namespace Frigorino.Infrastructure.Tasks
+{
+    // A distinct product name referenced by an active ListItem, tagged with its household
+    // (resolved via ListItem -> List -> HouseholdId). RawText is normalized by the helper.
+    public sealed record ListItemNameCandidate(int HouseholdId, string RawText);
+
+    // An existing product catalog row, reduced to the fields needed to decide staleness.
+    public sealed record ExistingProduct(int HouseholdId, string NormalizedName, int ClassifierVersion);
+
+    // A name needing (re)classification, carrying one representative raw name so the trigger/job
+    // normalizes it consistently with the live path.
+    public sealed record ClassificationGap(int HouseholdId, string RawName);
+
+    // Pure gap decision: which referenced names have no up-to-date Product (never classified, or
+    // below the current classifier version). Kept free of EF so it is unit-testable without a
+    // database (mirrors CheckedItemPurge).
+    public static class ProductClassificationGaps
+    {
+        public static List<ClassificationGap> SelectGaps(
+            IReadOnlyCollection<ListItemNameCandidate> candidates,
+            IReadOnlyCollection<ExistingProduct> existingProducts,
+            int currentClassifierVersion)
+        {
+            // Highest classifier version per (household, normalized name). The unique index makes
+            // duplicates unlikely, but Max keeps the decision well-defined regardless.
+            var versionByName = new Dictionary<(int Household, string Name), int>();
+            foreach (var product in existingProducts)
+            {
+                var key = (product.HouseholdId, product.NormalizedName);
+                if (!versionByName.TryGetValue(key, out var current) || product.ClassifierVersion > current)
+                {
+                    versionByName[key] = product.ClassifierVersion;
+                }
+            }
+
+            var gaps = new List<ClassificationGap>();
+            var seen = new HashSet<(int Household, string Name)>();
+            foreach (var candidate in candidates)
+            {
+                var normalized = ProductName.Normalize(candidate.RawText);
+                if (normalized.Length == 0)
+                {
+                    continue;
+                }
+
+                var key = (candidate.HouseholdId, normalized);
+                if (!seen.Add(key))
+                {
+                    continue;
+                }
+
+                var isUpToDate = versionByName.TryGetValue(key, out var version)
+                    && version >= currentClassifierVersion;
+                if (!isUpToDate)
+                {
+                    gaps.Add(new ClassificationGap(candidate.HouseholdId, candidate.RawText));
+                }
+            }
+
+            return gaps;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test Application/Frigorino.Test --filter "FullyQualifiedName~ProductClassificationGapsTests"`
+Expected: PASS (6 tests, 0 failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Application/Frigorino.Infrastructure/Tasks/ProductClassificationGaps.cs Application/Frigorino.Test/Infrastructure/ProductClassificationGapsTests.cs
+git commit -m "feat: add product classification gap-selection helper"
+```
+
+---
+
+## Task 2: The backfill maintenance task
+
+**Files:**
+- Create: `Application/Frigorino.Infrastructure/Tasks/BackfillProductClassification.cs`
+
+This task is thin glue over the Task 1 helper plus EF reads and the existing trigger; its logic is covered by the helper's unit tests (the same pattern as `DeleteInactiveItems`, which has no test of its own — only `CheckedItemPurge` does). It is verified by a successful build here and the full suite in Task 4.
+
+- [ ] **Step 1: Write the task**
+
+Create `Application/Frigorino.Infrastructure/Tasks/BackfillProductClassification.cs`:
+
+```csharp
+using Frigorino.Domain.Interfaces;
+using Frigorino.Infrastructure.EntityFramework;
+using Frigorino.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Frigorino.Infrastructure.Tasks
+{
+    // Startup backfill: enqueue classification for ListItem product names that have no up-to-date
+    // Product (never classified, or below the current ClassifierVersion). Idempotent and
+    // version-aware via the existing classify job; capped per run, with the remainder picked up on
+    // the next cold start (the queue is lossy, but loss here is recoverable by re-scanning).
+    public class BackfillProductClassification : IMaintenanceTask
+    {
+        private readonly ApplicationDbContext _dbContext;
+        private readonly IProductClassificationTrigger _trigger;
+        private readonly IItemClassifier _classifier;
+        private readonly ILogger<BackfillProductClassification> _logger;
+
+        public BackfillProductClassification(
+            ApplicationDbContext dbContext,
+            IProductClassificationTrigger trigger,
+            IItemClassifier classifier,
+            ILogger<BackfillProductClassification> logger)
+        {
+            _dbContext = dbContext;
+            _trigger = trigger;
+            _classifier = classifier;
+            _logger = logger;
+        }
+
+        public async Task Run(CancellationToken cancellationToken = default)
+        {
+            var candidates = await _dbContext.ListItems
+                .Where(li => li.IsActive)
+                .Select(li => new ListItemNameCandidate(li.List.HouseholdId, li.Text))
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            var existing = await _dbContext.Products
+                .Select(p => new ExistingProduct(p.HouseholdId, p.NormalizedName, p.ClassifierVersion))
+                .ToListAsync(cancellationToken);
+
+            var gaps = ProductClassificationGaps.SelectGaps(candidates, existing, _classifier.Version);
+            if (gaps.Count == 0)
+            {
+                return;
+            }
+
+            // Cap per run to the queue capacity so a large first backfill cannot overflow (and
+            // silently drop) the lossy queue; the remainder is enqueued on the next cold start.
+            var toEnqueue = gaps.Take(BackgroundTaskQueue.Capacity).ToList();
+            foreach (var gap in toEnqueue)
+            {
+                _trigger.OnProductReferenced(gap.HouseholdId, gap.RawName);
+            }
+
+            var deferred = gaps.Count - toEnqueue.Count;
+            _logger.LogInformation(
+                "Backfill classification: {Total} gap(s) found, {Enqueued} enqueued, {Deferred} deferred to next cold start.",
+                gaps.Count, toEnqueue.Count, deferred);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build Application/Frigorino.Infrastructure`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Application/Frigorino.Infrastructure/Tasks/BackfillProductClassification.cs
+git commit -m "feat: add backfill product classification maintenance task"
+```
+
+---
+
+## Task 3: Gated DI registration
+
+**Files:**
+- Modify: `Application/Frigorino.Infrastructure/Services/MaintenanceDependencyInjection.cs`
+- Modify: `Application/Frigorino.Web/Program.cs:85`
+
+The task injects `IItemClassifier` and the queueing `IProductClassificationTrigger`, both of which are registered only when `Ai:Classifier:Enabled` is true **and** an API key is present (see `ItemClassificationDependencyInjection`). Register the task under the identical condition so DI `ValidateOnBuild` cannot fail.
+
+- [ ] **Step 1: Update `AddMaintenanceServices`**
+
+Replace the entire contents of `Application/Frigorino.Infrastructure/Services/MaintenanceDependencyInjection.cs` with:
+
+```csharp
+using Frigorino.Domain.Interfaces;
+using Frigorino.Infrastructure.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Frigorino.Infrastructure.Services
+{
+    public static class MaintenanceDependencyInjection
+    {
+        public static IServiceCollection AddMaintenanceServices(
+            this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddScoped<IMaintenanceTask, DeleteInactiveItems>();
+
+            // Registered only when live classification is on (same condition as
+            // ItemClassificationDependencyInjection); otherwise IItemClassifier and the queueing
+            // trigger are not in the container and ValidateOnBuild would fail.
+            var classificationEnabled = configuration.GetValue<bool>("Ai:Classifier:Enabled");
+            var apiKey = configuration["Ai:ApiKey"];
+            if (classificationEnabled && !string.IsNullOrWhiteSpace(apiKey))
+            {
+                services.AddScoped<IMaintenanceTask, BackfillProductClassification>();
+            }
+
+            services.AddHostedService<MaintenanceHostedService>();
+
+            return services;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update the call site in `Program.cs`**
+
+In `Application/Frigorino.Web/Program.cs`, change line 85 from:
+
+```csharp
+builder.Services.AddMaintenanceServices();
+```
+
+to:
+
+```csharp
+builder.Services.AddMaintenanceServices(builder.Configuration);
+```
+
+- [ ] **Step 3: Build the web host to verify wiring compiles**
+
+Run: `dotnet build Application/Frigorino.Web`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Application/Frigorino.Infrastructure/Services/MaintenanceDependencyInjection.cs Application/Frigorino.Web/Program.cs
+git commit -m "feat: register backfill classification task when AI is enabled"
+```
+
+---
+
+## Task 4: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full solution test suite**
+
+Run: `dotnet test Application/Frigorino.sln`
+Expected: PASS — all existing tests plus the 6 new `ProductClassificationGapsTests`. Capture the pass/fail summary line; do not trust a piped exit code (use the printed totals).
+
+- [ ] **Step 2: Confirm no other call sites of `AddMaintenanceServices` were missed**
+
+Run: `git grep -n "AddMaintenanceServices"`
+Expected: exactly two hits — the definition in `MaintenanceDependencyInjection.cs` and the call in `Program.cs` (now passing `builder.Configuration`). If any other call site exists, update it to pass configuration.
+
+- [ ] **Step 3: Final commit (if Step 2 required a fix; otherwise skip)**
+
+```bash
+git add -A
+git commit -m "fix: pass configuration to remaining AddMaintenanceServices call sites"
+```
+
+> **Docker note:** No project was added/removed and the Dockerfile is unchanged, so a `docker build` is not required for this change. The full `dotnet test` run in Step 1 is the gate.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** gap helper (Task 1) ↔ spec §"Gap selection"; task + per-run cap + logging (Task 2) ↔ spec §"The maintenance task"; gated registration (Task 3) ↔ spec §"DI registration & AI-disabled behavior"; tests (Task 1) ↔ spec §"Testing"; error handling is inherited from `MaintenanceHostedService` (no code, noted in spec). Non-goals (orphan cleanup, inventory, new config) produce no tasks — correct.
+- **Type consistency:** `ListItemNameCandidate(HouseholdId, RawText)`, `ExistingProduct(HouseholdId, NormalizedName, ClassifierVersion)`, `ClassificationGap(HouseholdId, RawName)`, and `ProductClassificationGaps.SelectGaps(candidates, existingProducts, currentClassifierVersion)` are used identically in Tasks 1 and 2. `BackgroundTaskQueue.Capacity` (public const, `Frigorino.Infrastructure.Services`) and `IItemClassifier.Version` are referenced as defined in the existing code.
+- **No placeholders:** every code/command step is complete.

--- a/docs/superpowers/specs/2026-06-02-backfill-product-classification-design.md
+++ b/docs/superpowers/specs/2026-06-02-backfill-product-classification-design.md
@@ -1,0 +1,129 @@
+# Backfill Product Classification — Design
+
+**Date:** 2026-06-02
+**Branch:** `feat/backfill-product-classification`
+**Status:** Approved (brainstorming)
+
+## Problem
+
+The AI classification feature produces a `Product` row keyed by `(HouseholdId, NormalizedName)`,
+created/updated asynchronously by `ClassifyProductJob` when a ListItem is created or updated.
+Items added **before** the feature shipped — and any names whose classification predates a
+`ClassifierVersion` bump — have no up-to-date `Product`. We need a way to backfill classification
+for existing items without manual intervention.
+
+## Key facts that shape the design
+
+- Items (`ListItem`/`InventoryItem`) have **no FK** to `Product`; they reference it only by
+  normalized text (`ProductName.Normalize`) resolved at query time.
+- `ClassifyProductJob` is already **idempotent and version-aware**: it skips any product already
+  classified at or above the current `IItemClassifier.Version`. The "classify if not yet done"
+  logic therefore already exists at the product level.
+- The real unit of work is **not "every item"** — it is *every distinct normalized name referenced
+  by items that lacks an up-to-date `Product`*. The existing job handles the rest.
+- One "missing or stale" rule covers **two** cases: names never classified, and names whose
+  `Product.ClassifierVersion` is below the current version (post-bump re-sweep) — no extra code.
+
+## Scope decisions
+
+- **Backfill source: ListItems only.** Matches current classification behavior; InventoryItems are
+  not classified today and stay out of scope.
+- **No orphan-product cleanup.** Products act as a per-household classification cache; re-adding a
+  previously-removed item reuses the cached classification rather than paying for a new OpenAI call.
+  Orphaned rows are cheap and are deliberately retained.
+
+### Non-goals (YAGNI)
+
+- No orphan-`Product` cleanup task.
+- No `InventoryItem` classification.
+- No new config knobs beyond the existing `Ai:Classifier:Enabled` flag.
+
+## Approach (chosen: enqueue gaps via the existing trigger/queue)
+
+A new startup maintenance task scans active ListItem texts, computes the distinct names lacking an
+up-to-date `Product`, and enqueues each through the existing `IProductClassificationTrigger`
+(`OnProductReferenced`) — the exact path live classification uses. Each enqueued job then runs in
+its own DI scope via `QueuedHostedService`.
+
+Rationale over a synchronous in-task classify loop:
+
+- Reuses the proven live code path; per-job DI-scope isolation.
+- When AI is disabled the injected trigger is `NullProductClassificationTrigger`, so the task
+  naturally no-ops.
+- The 1000-item queue cap is a natural throttle: cap enqueues per run, log the remainder, and the
+  next cold start picks up what's left (idempotent). Progressive backfill across restarts.
+- The queue is lossy, but loss here is **recoverable** (re-scanned next cold start), unlike the
+  notification-ledger cron case where loss is unrecoverable. That is why the "cron batches send
+  synchronously" rule does not apply.
+
+## Components
+
+### 1. Gap-selection helper (pure, unit-testable)
+
+Mirrors the `CheckedItemPurge.SelectExpiredItemIds` pattern — a pure static helper so the logic is
+unit-testable without a DB.
+
+- **Input:**
+  - distinct `(HouseholdId, rawText)` pairs from **active** ListItems
+  - existing products as `(HouseholdId, NormalizedName, ClassifierVersion)`
+  - the current `IItemClassifier.Version`
+- **Logic:**
+  - normalize each raw text via `ProductName.Normalize` (C#-side — cannot run in SQL)
+  - dedupe to distinct `(HouseholdId, NormalizedName)`, keeping one representative raw name per name
+  - a name is a **gap** if no product exists for it, *or* its product's `ClassifierVersion < current`
+- **Output:** the list of gap `(HouseholdId, rawName)` to enqueue (one representative raw name per
+  gap so the trigger/job normalizes consistently).
+
+### 2. The maintenance task — `BackfillProductClassification : IMaintenanceTask`
+
+Located in `Frigorino.Infrastructure/Tasks/`, alongside `DeleteInactiveItems`. Injects
+`ApplicationDbContext` (read) and `IProductClassificationTrigger` (enqueue).
+
+1. Load distinct `(List.HouseholdId, Text)` from active ListItems (projection, not full entities).
+2. Load existing products' `(HouseholdId, NormalizedName, ClassifierVersion)`.
+3. Run the helper to compute gaps.
+4. Apply a **per-run cap** (= queue capacity, `1000`); enqueue each capped gap via
+   `trigger.OnProductReferenced(householdId, rawName)`.
+5. Log: total gaps found, number enqueued, and number deferred to the next cold start when capped
+   (so silent truncation is visible). The remainder is picked up on the next cold start (idempotent).
+
+### 3. DI registration & AI-disabled behavior
+
+Register in `AddMaintenanceServices`, gated on the same `Ai:Classifier:Enabled` flag that
+`ItemClassificationDependencyInjection` uses — so when AI is off the task is not registered at all
+(no pointless scan). Belt-and-suspenders: even if it ran, the injected trigger would be
+`NullProductClassificationTrigger` and enqueue nothing.
+
+### 4. Error handling
+
+Inherits `MaintenanceHostedService`'s per-task try/catch — a failure logs and never crashes startup.
+Individual job failures are already isolated inside `QueuedHostedService` and the job's own
+race-safe handling.
+
+## Runtime characteristics
+
+- Runs once per cold start (Railway sleeps on idle), 5s after boot, in its own DI scope.
+- Steady state after a successful backfill: the scan finds no gaps and enqueues nothing — cost is
+  just the DB scan.
+- After a `ClassifierVersion` bump: the next cold start re-sweeps stale products automatically.
+- First run on a large dataset: capped at 1000 enqueues; remainder backfilled across subsequent
+  cold starts.
+
+## Testing
+
+- **Unit-test the pure helper** (xUnit, no DB):
+  - never-classified name → gap
+  - up-to-date product → skipped
+  - stale-version product (`ClassifierVersion < current`) → gap
+  - multiple raw spellings normalizing to one name → single gap
+  - per-household isolation (same name in two households → two independent gaps)
+- **No integration test** — reuses the proven live classification path.
+
+## Files (anticipated)
+
+- `Frigorino.Infrastructure/Tasks/BackfillProductClassification.cs` — new task
+- `Frigorino.Infrastructure/Tasks/ProductClassificationGaps.cs` — pure gap-selection helper,
+  placed alongside the task to match the `CheckedItemPurge` precedent
+- `Frigorino.Infrastructure/Services/MaintenanceDependencyInjection.cs` — gated registration
+- `Frigorino.Test/Infrastructure/ProductClassificationGapsTests.cs` — unit tests for the helper
+  (mirrors `CheckedItemPurgeTests` placement)


### PR DESCRIPTION
## Summary
- Adds a startup maintenance task (`BackfillProductClassification : IMaintenanceTask`) that enqueues AI classification for existing **ListItem** product names lacking an up-to-date `Product` (never classified, or below the current `ClassifierVersion`).
- The decision lives in a pure, unit-tested helper (`ProductClassificationGaps.SelectGaps`) mirroring the `CheckedItemPurge` pattern; the task is thin glue (load → helper → cap → enqueue → log).
- Reuses the live classification path: enqueues via `IProductClassificationTrigger.OnProductReferenced`, capped at the `BackgroundTaskQueue` capacity so a large first backfill can't overflow the lossy queue — the remainder is picked up on the next cold start (idempotent + version-aware job).
- Registration is gated on the same `Ai:Classifier:Enabled` + API-key condition as live classification (no `ValidateOnBuild` risk); `Program.cs` now passes `builder.Configuration` to `AddMaintenanceServices`.

### Deliberate non-goals (YAGNI)
- No orphan-`Product` cleanup — products are an intentional per-household cache.
- No `InventoryItem` classification.
- No new config knobs.

### Notes
- A `ClassifierVersion` bump triggers an automatic re-classification sweep on the next cold start, no extra code.
- Items on soft-deleted lists are excluded (`li.IsActive && li.List.IsActive`) for parity with live classification reachability.

Design spec + plan committed under `docs/superpowers/`.

## Test Plan
- [x] `Frigorino.Test` — 7 new `ProductClassificationGapsTests` (never-classified, up-to-date skip, stale-version, multi-spelling normalize, per-household isolation, blank-text skip, highest-version-wins); full project **370/370** pass.
- [x] `Frigorino.IntegrationTests` — **111/111** pass (full sln run with Testcontainers + SPA build).
- [x] Backend-only change; no schema migration, no SPA change.