### PR TITLE
UX alignment: palette, dashboard clarity, expiry chips, standardized headers, section identity

### DIFF
--- a/Application/Frigorino.Features/Inventories/CreateInventory.cs
+++ b/Application/Frigorino.Features/Inventories/CreateInventory.cs
@@ -50,7 +50,7 @@ namespace Frigorino.Features.Inventories
             db.Inventories.Add(inventory);
             await db.SaveChangesAsync(ct);
 
-            var response = InventoryResponse.From(inventory, creator, totalItems: 0, expiringItems: 0);
+            var response = InventoryResponse.From(inventory, creator, totalItems: 0, expiringItems: 0, earliestExpiryDate: null);
             return TypedResults.Created($"/api/household/{householdId}/inventories/{inventory.Id}", response);
         }
     }

--- a/Application/Frigorino.Features/Inventories/InventoryResponse.cs
+++ b/Application/Frigorino.Features/Inventories/InventoryResponse.cs
@@ -12,14 +12,15 @@ namespace Frigorino.Features.Inventories
         DateTime UpdatedAt,
         InventoryCreatorResponse CreatedByUser,
         int TotalItems,
-        int ExpiringItems)
+        int ExpiringItems,
+        DateOnly? EarliestExpiryDate)
     {
         // Threshold (in days) for the "expiring soon" highlight on inventory items. Shared by
         // both the aggregate-count projection here and InventoryItemResponse.IsExpiring so the
         // overview card count and per-item flag stay in sync.
         public const int ExpiringWithinDays = 7;
 
-        public static InventoryResponse From(Inventory inventory, User creator, int totalItems, int expiringItems)
+        public static InventoryResponse From(Inventory inventory, User creator, int totalItems, int expiringItems, DateOnly? earliestExpiryDate)
         {
             return new InventoryResponse(
                 inventory.Id,
@@ -30,7 +31,8 @@ namespace Frigorino.Features.Inventories
                 inventory.UpdatedAt,
                 new InventoryCreatorResponse(creator.ExternalId, creator.Name, creator.Email),
                 totalItems,
-                expiringItems);
+                expiringItems,
+                earliestExpiryDate);
         }
 
         // EF-translatable projection used by read slices (GetInventory, GetInventories). Lifted
@@ -47,7 +49,12 @@ namespace Frigorino.Features.Inventories
             i.UpdatedAt,
             new InventoryCreatorResponse(i.CreatedByUser.ExternalId, i.CreatedByUser.Name, i.CreatedByUser.Email),
             i.InventoryItems.Count(x => x.IsActive),
-            i.InventoryItems.Count(x => x.IsActive && x.ExpiryDate.HasValue && x.ExpiryDate.Value <= DateOnly.FromDateTime(DateTime.UtcNow).AddDays(ExpiringWithinDays)));
+            i.InventoryItems.Count(x => x.IsActive && x.ExpiryDate.HasValue && x.ExpiryDate.Value <= DateOnly.FromDateTime(DateTime.UtcNow).AddDays(ExpiringWithinDays)),
+            i.InventoryItems
+                .Where(x => x.IsActive && x.ExpiryDate != null)
+                .OrderBy(x => x.ExpiryDate)
+                .Select(x => x.ExpiryDate)
+                .FirstOrDefault());
     }
 
     public sealed record InventoryCreatorResponse(

--- a/Application/Frigorino.Features/Inventories/UpdateInventory.cs
+++ b/Application/Frigorino.Features/Inventories/UpdateInventory.cs
@@ -64,11 +64,17 @@ namespace Frigorino.Features.Inventories
             await db.SaveChangesAsync(ct);
 
             var threshold = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(InventoryResponse.ExpiringWithinDays);
+            var earliestExpiry = inventory.InventoryItems
+                .Where(x => x.IsActive && x.ExpiryDate != null)
+                .OrderBy(x => x.ExpiryDate)
+                .Select(x => x.ExpiryDate)
+                .FirstOrDefault();
             var response = InventoryResponse.From(
                 inventory,
                 inventory.CreatedByUser,
                 inventory.InventoryItems.Count(x => x.IsActive),
-                inventory.InventoryItems.Count(x => x.IsActive && x.ExpiryDate.HasValue && x.ExpiryDate.Value <= threshold));
+                inventory.InventoryItems.Count(x => x.IsActive && x.ExpiryDate.HasValue && x.ExpiryDate.Value <= threshold),
+                earliestExpiry);
             return TypedResults.Ok(response);
         }
     }

--- a/Application/Frigorino.Test/Features/InventoryResponseProjectionTests.cs
+++ b/Application/Frigorino.Test/Features/InventoryResponseProjectionTests.cs
@@ -1,0 +1,62 @@
+using Frigorino.Domain.Entities;
+using Frigorino.Features.Inventories;
+
+namespace Frigorino.Test.Features
+{
+    public class InventoryResponseProjectionTests
+    {
+        private static Inventory BuildInventory(params InventoryItem[] items)
+        {
+            return new Inventory
+            {
+                Id = 1,
+                Name = "Fridge",
+                Description = null,
+                HouseholdId = 1,
+                CreatedByUser = new User
+                {
+                    ExternalId = "u1",
+                    Name = "Tester",
+                    Email = "t@example.com",
+                },
+                InventoryItems = items.ToList(),
+            };
+        }
+
+        [Fact]
+        public void EarliestExpiryDate_IsMinAmongActiveItemsWithDate()
+        {
+            var inventory = BuildInventory(
+                new InventoryItem { IsActive = true, ExpiryDate = new DateOnly(2026, 7, 1) },
+                new InventoryItem { IsActive = true, ExpiryDate = new DateOnly(2026, 6, 10) },
+                new InventoryItem { IsActive = true, ExpiryDate = null });
+
+            var result = InventoryResponse.ToProjection.Compile().Invoke(inventory);
+
+            Assert.Equal(new DateOnly(2026, 6, 10), result.EarliestExpiryDate);
+        }
+
+        [Fact]
+        public void EarliestExpiryDate_IgnoresInactiveItems()
+        {
+            var inventory = BuildInventory(
+                new InventoryItem { IsActive = false, ExpiryDate = new DateOnly(2026, 1, 1) },
+                new InventoryItem { IsActive = true, ExpiryDate = new DateOnly(2026, 6, 10) });
+
+            var result = InventoryResponse.ToProjection.Compile().Invoke(inventory);
+
+            Assert.Equal(new DateOnly(2026, 6, 10), result.EarliestExpiryDate);
+        }
+
+        [Fact]
+        public void EarliestExpiryDate_IsNullWhenNoItemHasDate()
+        {
+            var inventory = BuildInventory(
+                new InventoryItem { IsActive = true, ExpiryDate = null });
+
+            var result = InventoryResponse.ToProjection.Compile().Invoke(inventory);
+
+            Assert.Null(result.EarliestExpiryDate);
+        }
+    }
+}

--- a/Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
+++ b/Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
@@ -247,6 +247,8 @@
         "items": "Artikel",
         "articles": "Artikel",
         "expiring": "läuft ab",
+        "open": "offen",
+        "itemsTotal": "Artikel gesamt",
         "recipes": "Rezepte",
         "comingSoon": "Demnächst verfügbar...",
         "recipeManagementLater": "Rezeptverwaltung wird später hinzugefügt"

--- a/Application/Frigorino.Web/ClientApp/public/locales/en/translation.json
+++ b/Application/Frigorino.Web/ClientApp/public/locales/en/translation.json
@@ -247,6 +247,8 @@
         "items": "Items",
         "articles": "Articles",
         "expiring": "expiring",
+        "open": "open",
+        "itemsTotal": "items total",
         "recipes": "Recipes",
         "comingSoon": "Coming soon...",
         "recipeManagementLater": "Recipe management will be added later"

--- a/Application/Frigorino.Web/ClientApp/src/common/sections.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/common/sections.tsx
@@ -1,0 +1,19 @@
+import {
+    ChecklistOutlined,
+    HomeOutlined,
+    KitchenOutlined,
+    RestaurantOutlined,
+    type SvgIconComponent,
+} from "@mui/icons-material";
+import { type SectionKey } from "../theme";
+
+// Section icon components, kept alongside `sectionColors` (theme.ts) so every
+// surface — dashboard cards and page headers — shows the same glyph + hue per
+// section. Lists = checklist, Inventory = fridge, Recipes = cutlery,
+// Household = home.
+export const sectionIcons: Record<SectionKey, SvgIconComponent> = {
+    household: HomeOutlined,
+    lists: ChecklistOutlined,
+    inventory: KitchenOutlined,
+    recipes: RestaurantOutlined,
+};

--- a/Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx
@@ -1,10 +1,4 @@
-import {
-    Add,
-    ChevronRight,
-    KitchenOutlined,
-    RestaurantOutlined,
-    TimerOutlined,
-} from "@mui/icons-material";
+import { Add, ChevronRight } from "@mui/icons-material";
 import {
     Box,
     Card,
@@ -16,7 +10,6 @@ import {
     IconButton,
     List,
     ListItem,
-    ListItemIcon,
     ListItemText,
     Stack,
     Typography,
@@ -37,6 +30,8 @@ import {
     getExpiryColor,
     getExpiryInfo,
 } from "../../utils/dateUtils";
+import { sectionColors } from "../../theme";
+import { sectionIcons } from "../../common/sections";
 
 export const WelcomePage = () => {
     const { user } = useAuth();
@@ -123,12 +118,16 @@ export const WelcomePage = () => {
         }
     };
 
+    const ListsIcon = sectionIcons.lists;
+    const InventoryIcon = sectionIcons.inventory;
+    const RecipesIcon = sectionIcons.recipes;
+
     const collections = [
         {
             id: "einkaufslisten",
             label: t("lists.shoppingLists"),
-            icon: <KitchenOutlined />,
-            color: "#2196F3",
+            icon: <ListsIcon />,
+            color: sectionColors.lists,
             items: listsLoading
                 ? [
                       {
@@ -157,8 +156,8 @@ export const WelcomePage = () => {
         {
             id: "inventar",
             label: t("navigation.inventory"),
-            icon: <TimerOutlined />,
-            color: "#FF9800",
+            icon: <InventoryIcon />,
+            color: sectionColors.inventory,
             items: inventoriesLoading
                 ? [
                       {
@@ -204,8 +203,8 @@ export const WelcomePage = () => {
         {
             id: "rezepte",
             label: t("dashboard.recipes"),
-            icon: <RestaurantOutlined />,
-            color: "#4CAF50",
+            icon: <RecipesIcon />,
+            color: sectionColors.recipes,
             items: [
                 {
                     name: t("dashboard.comingSoon"),
@@ -333,7 +332,7 @@ export const WelcomePage = () => {
                                             sx={{
                                                 p: 1.5,
                                                 borderRadius: 2,
-                                                bgcolor: `${collection.color}15`,
+                                                bgcolor: "action.hover",
                                                 color: collection.color,
                                                 display: "flex",
                                                 alignItems: "center",
@@ -368,12 +367,11 @@ export const WelcomePage = () => {
                                                 handleAddItem(collection.id);
                                             }}
                                             sx={{
-                                                bgcolor: `${collection.color}15`,
-                                                color: collection.color,
+                                                color: "text.secondary",
                                                 width: 32,
                                                 height: 32,
                                                 "&:hover": {
-                                                    bgcolor: `${collection.color}25`,
+                                                    bgcolor: "action.hover",
                                                 },
                                             }}
                                         >
@@ -397,11 +395,11 @@ export const WelcomePage = () => {
                                                 }
                                             }}
                                             sx={{
-                                                color: collection.color,
+                                                color: "text.secondary",
                                                 width: 32,
                                                 height: 32,
                                                 "&:hover": {
-                                                    bgcolor: `${collection.color}15`,
+                                                    bgcolor: "action.hover",
                                                 },
                                             }}
                                         >
@@ -471,20 +469,6 @@ export const WelcomePage = () => {
                                                             : undefined
                                                     }
                                                 >
-                                                    <ListItemIcon
-                                                        sx={{ minWidth: 36 }}
-                                                    >
-                                                        <Box
-                                                            sx={{
-                                                                width: 8,
-                                                                height: 8,
-                                                                borderRadius:
-                                                                    "50%",
-                                                                bgcolor:
-                                                                    collection.color,
-                                                            }}
-                                                        />
-                                                    </ListItemIcon>
                                                     <ListItemText
                                                         primary={
                                                             <Box

--- a/Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx
@@ -133,10 +133,8 @@ export const WelcomePage = () => {
                 : lists.length > 0
                   ? lists.map((list) => ({
                         name: list.name || "Unnamed List",
-                        count: `${list.checkedCount}/${list.uncheckedCount} ${t("dashboard.articles")}`,
-                        status: new Date(list.createdAt!).toLocaleDateString(
-                            "de-DE",
-                        ),
+                        count: `${list.uncheckedCount} ${t("dashboard.open")}`,
+                        status: `${list.uncheckedCount + list.checkedCount} ${t("dashboard.itemsTotal")}`,
                         id: list.id,
                     }))
                   : [
@@ -500,7 +498,7 @@ export const WelcomePage = () => {
                                                                 />
                                                             </Box>
                                                         }
-                                                        secondary={item.count}
+                                                        secondary={item.status}
                                                     />
                                                 </ListItem>
                                             );

--- a/Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx
@@ -32,11 +32,19 @@ import { useHouseholdInventories } from "../../features/inventories/useHousehold
 import { useHouseholdLists } from "../../features/lists/useHouseholdLists";
 import { useLongPress } from "../../hooks/useLongPress";
 import { HeroImage } from "../common/HeroImage";
+import {
+    formatLocalDate,
+    getExpiryColor,
+    getExpiryInfo,
+} from "../../utils/dateUtils";
 
 export const WelcomePage = () => {
     const { user } = useAuth();
     const navigate = useNavigate();
     const { t } = useTranslation();
+    // getExpiryInfo expects a plain (key) => string; the i18n t has stricter overloads.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const translateKey = (key: string): string => t(key as any);
 
     // Local storage key for expanded sections
     const EXPANDED_SECTIONS_KEY = "frigorino-welcome-expanded-sections";
@@ -161,16 +169,29 @@ export const WelcomePage = () => {
                       },
                   ]
                 : inventories.length > 0
-                  ? inventories.map((inventory) => ({
-                        name: inventory.name || "Unnamed Inventory",
-                        count: `${inventory.totalItems || 0} ${t("dashboard.items")}`,
-                        status:
-                            inventory.expiringItems &&
-                            inventory.expiringItems > 0
-                                ? `${inventory.expiringItems} ${t("dashboard.expiring")}`
-                                : t("common.current"),
-                        id: inventory.id,
-                    }))
+                  ? inventories.map((inventory) => {
+                        const expiry = inventory.earliestExpiryDate;
+                        const expiryChip = expiry
+                            ? {
+                                  label:
+                                      getExpiryInfo(expiry, translateKey)
+                                          .humanReadable ||
+                                      formatLocalDate(expiry),
+                                  color: getExpiryColor(expiry),
+                              }
+                            : null;
+                        return {
+                            name: inventory.name || "Unnamed Inventory",
+                            count: `${inventory.totalItems || 0} ${t("dashboard.items")}`,
+                            status:
+                                inventory.expiringItems &&
+                                inventory.expiringItems > 0
+                                    ? `${inventory.expiringItems} ${t("dashboard.expiring")}`
+                                    : t("common.current"),
+                            id: inventory.id,
+                            expiryChip,
+                        };
+                    })
                   : [
                         {
                             name: t("inventory.noInventoriesYet"),
@@ -484,18 +505,53 @@ export const WelcomePage = () => {
                                                                 >
                                                                     {item.name}
                                                                 </Typography>
-                                                                <Chip
-                                                                    label={
-                                                                        item.count
-                                                                    }
-                                                                    size="small"
-                                                                    variant="outlined"
+                                                                <Box
                                                                     sx={{
-                                                                        fontSize:
-                                                                            "0.7rem",
-                                                                        height: 20,
+                                                                        display:
+                                                                            "flex",
+                                                                        alignItems:
+                                                                            "center",
+                                                                        gap: 0.5,
                                                                     }}
-                                                                />
+                                                                >
+                                                                    {"expiryChip" in
+                                                                        item &&
+                                                                        item.expiryChip && (
+                                                                            <Chip
+                                                                                label={
+                                                                                    item
+                                                                                        .expiryChip
+                                                                                        .label
+                                                                                }
+                                                                                size="small"
+                                                                                variant="outlined"
+                                                                                sx={{
+                                                                                    fontSize:
+                                                                                        "0.7rem",
+                                                                                    height: 20,
+                                                                                    color: item
+                                                                                        .expiryChip
+                                                                                        .color,
+                                                                                    borderColor:
+                                                                                        item
+                                                                                            .expiryChip
+                                                                                            .color,
+                                                                                }}
+                                                                            />
+                                                                        )}
+                                                                    <Chip
+                                                                        label={
+                                                                            item.count
+                                                                        }
+                                                                        size="small"
+                                                                        variant="outlined"
+                                                                        sx={{
+                                                                            fontSize:
+                                                                                "0.7rem",
+                                                                            height: 20,
+                                                                        }}
+                                                                    />
+                                                                </Box>
                                                             </Box>
                                                         }
                                                         secondary={item.status}

--- a/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
@@ -12,6 +12,8 @@ import {
 } from "@mui/material";
 import { useRouter } from "@tanstack/react-router";
 import { memo, useCallback, useState } from "react";
+import { sectionIcons } from "../../common/sections";
+import { sectionColors, type SectionKey } from "../../theme";
 
 export type HeadNavigationAction = {
     text?: string;
@@ -31,6 +33,10 @@ export interface HeadNavigationProps {
     directActions: HeadNavigationAction[];
     maxWidth?: Breakpoint;
     menuButtonTestId?: string;
+    // When set, shows the section's identity icon (section-colored glyph on a
+    // neutral surface) before the title — the same wayfinding cue used on the
+    // dashboard, continued into the feature.
+    section?: SectionKey;
 }
 
 export const PageHeadActionBar = memo(
@@ -41,8 +47,11 @@ export const PageHeadActionBar = memo(
         directActions,
         maxWidth = "sm",
         menuButtonTestId,
+        section,
     }: HeadNavigationProps) => {
         const router = useRouter();
+        const SectionIcon = section ? sectionIcons[section] : null;
+        const sectionColor = section ? sectionColors[section] : undefined;
         const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(
             null,
         );
@@ -86,6 +95,21 @@ export const PageHeadActionBar = memo(
                         <IconButton onClick={handleBack} sx={{ p: 1 }}>
                             <ArrowBack />
                         </IconButton>
+                        {SectionIcon && (
+                            <Box
+                                sx={{
+                                    p: 1,
+                                    borderRadius: 2,
+                                    bgcolor: "action.hover",
+                                    color: sectionColor,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    flexShrink: 0,
+                                }}
+                            >
+                                <SectionIcon />
+                            </Box>
+                        )}
                         <Box sx={{ flex: 1 }}>
                             <Typography
                                 variant="h5"

--- a/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
@@ -1,6 +1,7 @@
 import { ArrowBack, MoreVert } from "@mui/icons-material";
 import {
     Box,
+    type Breakpoint,
     Container,
     IconButton,
     ListItemIcon,
@@ -25,10 +26,19 @@ export interface HeadNavigationProps {
     subtitle?: string;
     menuActions: HeadNavigationAction[];
     directActions: HeadNavigationAction[];
+    maxWidth?: Breakpoint;
+    menuButtonTestId?: string;
 }
 
 export const PageHeadActionBar = memo(
-    ({ title, subtitle, menuActions, directActions }: HeadNavigationProps) => {
+    ({
+        title,
+        subtitle,
+        menuActions,
+        directActions,
+        maxWidth = "sm",
+        menuButtonTestId,
+    }: HeadNavigationProps) => {
         const router = useRouter();
         const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(
             null,
@@ -60,7 +70,7 @@ export const PageHeadActionBar = memo(
         return (
             <>
                 <Container
-                    maxWidth="sm"
+                    maxWidth={maxWidth}
                     sx={{ px: 1.5, py: 1.5, flexShrink: 0 }}
                 >
                     <Box
@@ -120,6 +130,7 @@ export const PageHeadActionBar = memo(
                             {menuActions.length > 0 && (
                                 <IconButton
                                     onClick={handleMenuOpen}
+                                    data-testid={menuButtonTestId}
                                     sx={{
                                         bgcolor: "grey.100",
                                         color: "grey.700",
@@ -150,6 +161,7 @@ export const PageHeadActionBar = memo(
                             <MenuItem
                                 key={index}
                                 onClick={() => handleMenuAction(action)}
+                                data-testid={action.testId}
                             >
                                 {action.icon && (
                                     <ListItemIcon>{action.icon}</ListItemIcon>

--- a/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
@@ -19,6 +19,9 @@ export type HeadNavigationAction = {
     icon?: React.ReactNode;
     onClick: () => void;
     testId?: string;
+    // "error" renders the menu item in the destructive (red) color, matching the
+    // overview cards' delete styling so destructive actions look consistent everywhere.
+    color?: "error";
 };
 
 export interface HeadNavigationProps {
@@ -162,6 +165,11 @@ export const PageHeadActionBar = memo(
                                 key={index}
                                 onClick={() => handleMenuAction(action)}
                                 data-testid={action.testId}
+                                sx={
+                                    action.color === "error"
+                                        ? { color: "error.main" }
+                                        : undefined
+                                }
                             >
                                 {action.icon && (
                                     <ListItemIcon>{action.icon}</ListItemIcon>

--- a/Application/Frigorino.Web/ClientApp/src/features/households/pages/ManageHouseholdPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/households/pages/ManageHouseholdPage.tsx
@@ -80,9 +80,10 @@ export function ManageHouseholdPage() {
         ? [
               {
                   text: t("household.deleteHousehold"),
-                  icon: <Delete fontSize="small" />,
+                  icon: <Delete fontSize="small" color="error" />,
                   onClick: () => setDeleteDialogOpen(true),
                   testId: "household-manage-menu-delete",
+                  color: "error",
               },
           ]
         : [];

--- a/Application/Frigorino.Web/ClientApp/src/features/households/pages/ManageHouseholdPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/households/pages/ManageHouseholdPage.tsx
@@ -92,6 +92,7 @@ export function ManageHouseholdPage() {
         <>
             <PageHeadActionBar
                 title={t("household.householdManagement")}
+                section="household"
                 maxWidth="md"
                 directActions={[]}
                 menuActions={menuActions}

--- a/Application/Frigorino.Web/ClientApp/src/features/households/pages/ManageHouseholdPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/households/pages/ManageHouseholdPage.tsx
@@ -1,19 +1,11 @@
-import { ArrowBack, Delete, MoreVert } from "@mui/icons-material";
-import {
-    Alert,
-    Box,
-    Container,
-    IconButton,
-    ListItemIcon,
-    ListItemText,
-    Menu,
-    MenuItem,
-    Skeleton,
-    Typography,
-} from "@mui/material";
-import { useNavigate } from "@tanstack/react-router";
+import { Delete } from "@mui/icons-material";
+import { Alert, Box, Container, Skeleton } from "@mui/material";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+    PageHeadActionBar,
+    type HeadNavigationAction,
+} from "../../../components/shared/PageHeadActionBar";
 import { pageContainerSx } from "../../../theme";
 import { useCurrentHouseholdWithDetails } from "../../me/activeHousehold/useCurrentHouseholdWithDetails";
 import { DeleteHouseholdDialog } from "../components/DeleteHouseholdDialog";
@@ -24,10 +16,8 @@ import { MembersPanel } from "../members/components/MembersPanel";
 import { useHouseholdMembers } from "../members/useHouseholdMembers";
 
 export function ManageHouseholdPage() {
-    const navigate = useNavigate();
     const { t } = useTranslation();
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-    const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
 
     const {
         currentHousehold,
@@ -86,102 +76,52 @@ export function ManageHouseholdPage() {
     const canManageSettings =
         !!role && roleRank[role] >= roleRank[HouseholdRoleValue.Admin];
 
+    const menuActions: HeadNavigationAction[] = isOwner
+        ? [
+              {
+                  text: t("household.deleteHousehold"),
+                  icon: <Delete fontSize="small" />,
+                  onClick: () => setDeleteDialogOpen(true),
+                  testId: "household-manage-menu-delete",
+              },
+          ]
+        : [];
+
     return (
-        <Container maxWidth="md" sx={pageContainerSx}>
-            <Box sx={{ mb: { xs: 2, sm: 3 } }}>
-                <Box
-                    sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: { xs: 1, sm: 2 },
-                        mb: { xs: 2, sm: 3 },
-                    }}
-                >
-                    <IconButton onClick={() => navigate({ to: "/" })}>
-                        <ArrowBack />
-                    </IconButton>
-
-                    <Typography
-                        variant="h5"
-                        component="h1"
-                        sx={{ fontWeight: 600, flexGrow: 1 }}
-                    >
-                        {t("household.householdManagement")}
-                    </Typography>
-
-                    {isOwner && (
-                        <IconButton
-                            data-testid="household-manage-menu-toggle"
-                            onClick={(e) => setMenuAnchor(e.currentTarget)}
-                            size="small"
-                            sx={{
-                                bgcolor: "background.paper",
-                                border: 1,
-                                borderColor: "divider",
-                                "&:hover": { bgcolor: "action.hover" },
-                            }}
-                        >
-                            <MoreVert fontSize="small" />
-                        </IconButton>
-                    )}
+        <>
+            <PageHeadActionBar
+                title={t("household.householdManagement")}
+                maxWidth="md"
+                directActions={[]}
+                menuActions={menuActions}
+                menuButtonTestId="household-manage-menu-toggle"
+            />
+            <Container maxWidth="md" sx={pageContainerSx}>
+                <Box sx={{ mb: { xs: 2, sm: 3 } }}>
+                    <HouseholdSummaryCard
+                        householdName={householdName}
+                        memberCount={members?.length ?? 0}
+                        userRole={userRole}
+                    />
                 </Box>
 
-                <HouseholdSummaryCard
-                    householdName={householdName}
-                    memberCount={members?.length ?? 0}
-                    userRole={userRole}
+                <MembersPanel
+                    householdId={currentHousehold.householdId}
+                    currentUserRole={userRole}
                 />
-            </Box>
 
-            <MembersPanel
-                householdId={currentHousehold.householdId}
-                currentUserRole={userRole}
-            />
+                <HouseholdSettingsCard
+                    householdId={currentHousehold.householdId}
+                    canManage={canManageSettings}
+                />
 
-            <HouseholdSettingsCard
-                householdId={currentHousehold.householdId}
-                canManage={canManageSettings}
-            />
-
-            <Menu
-                anchorEl={menuAnchor}
-                open={Boolean(menuAnchor)}
-                onClose={() => setMenuAnchor(null)}
-                elevation={4}
-                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-                transformOrigin={{ vertical: "top", horizontal: "right" }}
-                slotProps={{
-                    paper: { sx: { minWidth: 200, mt: 1 } },
-                }}
-            >
-                <MenuItem
-                    data-testid="household-manage-menu-delete"
-                    onClick={() => {
-                        setDeleteDialogOpen(true);
-                        setMenuAnchor(null);
-                    }}
-                    sx={{
-                        color: "error.main",
-                        py: 1.5,
-                        "&:hover": {
-                            bgcolor: "error.light",
-                            color: "error.contrastText",
-                        },
-                    }}
-                >
-                    <ListItemIcon>
-                        <Delete fontSize="small" color="error" />
-                    </ListItemIcon>
-                    <ListItemText primary={t("household.deleteHousehold")} />
-                </MenuItem>
-            </Menu>
-
-            <DeleteHouseholdDialog
-                open={deleteDialogOpen}
-                onClose={() => setDeleteDialogOpen(false)}
-                householdId={currentHousehold.householdId}
-                householdName={householdName}
-            />
-        </Container>
+                <DeleteHouseholdDialog
+                    open={deleteDialogOpen}
+                    onClose={() => setDeleteDialogOpen(false)}
+                    householdId={currentHousehold.householdId}
+                    householdName={householdName}
+                />
+            </Container>
+        </>
     );
 }

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/components/InventoryActionsMenu.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/components/InventoryActionsMenu.tsx
@@ -1,11 +1,10 @@
-import { Delete, Edit } from "@mui/icons-material";
+import { Delete } from "@mui/icons-material";
 import { Menu, MenuItem } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 interface InventoryActionsMenuProps {
     anchorEl: HTMLElement | null;
     onClose: () => void;
-    onEdit: () => void;
     onDelete: () => void;
     isDeleting?: boolean;
 }
@@ -13,7 +12,6 @@ interface InventoryActionsMenuProps {
 export const InventoryActionsMenu = ({
     anchorEl,
     onClose,
-    onEdit,
     onDelete,
     isDeleting = false,
 }: InventoryActionsMenuProps) => {
@@ -27,10 +25,6 @@ export const InventoryActionsMenu = ({
             elevation={4}
             slotProps={{ paper: { sx: { minWidth: 160 } } }}
         >
-            <MenuItem onClick={onEdit} disabled>
-                <Edit fontSize="small" sx={{ mr: 1 }} />
-                {t("common.edit")}
-            </MenuItem>
             <MenuItem
                 onClick={onDelete}
                 disabled={isDeleting}

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/components/InventorySummaryCard.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/components/InventorySummaryCard.tsx
@@ -10,7 +10,13 @@ import {
     List as MuiList,
     Typography,
 } from "@mui/material";
+import { useTranslation } from "react-i18next";
 import type { InventoryResponse } from "../../../lib/api";
+import {
+    formatLocalDate,
+    getExpiryColor,
+    getExpiryInfo,
+} from "../../../utils/dateUtils";
 
 interface InventorySummaryCardProps {
     inventory: InventoryResponse;
@@ -35,6 +41,17 @@ export const InventorySummaryCard = ({
     onMenuOpen,
     menuDisabled = false,
 }: InventorySummaryCardProps) => {
+    const { t } = useTranslation();
+    // getExpiryInfo expects a plain (key) => string; the i18n t has stricter overloads.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const translateKey = (key: string): string => t(key as any);
+
+    const expiry = inventory.earliestExpiryDate;
+    const expiryLabel = expiry
+        ? getExpiryInfo(expiry, translateKey).humanReadable ||
+          formatLocalDate(expiry)
+        : null;
+
     return (
         <Card elevation={1}>
             <CardContent sx={{ py: 2 }}>
@@ -55,6 +72,18 @@ export const InventorySummaryCard = ({
                                     gap: 1,
                                 }}
                             >
+                                {expiry && expiryLabel && (
+                                    <Chip
+                                        label={expiryLabel}
+                                        size="small"
+                                        variant="outlined"
+                                        data-testid={`inventory-earliest-expiry-${inventory.name}`}
+                                        sx={{
+                                            color: getExpiryColor(expiry),
+                                            borderColor: getExpiryColor(expiry),
+                                        }}
+                                    />
+                                )}
                                 <Chip
                                     label={
                                         inventory.createdAt

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx
@@ -1,4 +1,4 @@
-import { Add, ArrowBack } from "@mui/icons-material";
+import { Add } from "@mui/icons-material";
 import {
     Alert,
     Box,
@@ -7,7 +7,6 @@ import {
     CardContent,
     CircularProgress,
     Container,
-    IconButton,
     Stack,
     Typography,
 } from "@mui/material";
@@ -16,6 +15,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { InventoryResponse } from "../../../lib/api";
 import { pageContainerSx } from "../../../theme";
+import { PageHeadActionBar } from "../../../components/shared/PageHeadActionBar";
 import { useCurrentHousehold } from "../../me/activeHousehold/useCurrentHousehold";
 import { InventoryActionsMenu } from "../components/InventoryActionsMenu";
 import { InventorySummaryCard } from "../components/InventorySummaryCard";
@@ -86,43 +86,15 @@ export const InventoriesPage = () => {
     }
 
     return (
-        <Container maxWidth="sm" sx={pageContainerSx}>
-            <Box
-                sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    mb: { xs: 2, sm: 3 },
-                }}
-            >
-                <Box
-                    sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: { xs: 1, sm: 2 },
-                    }}
-                >
-                    <IconButton onClick={handleBack}>
-                        <ArrowBack />
-                    </IconButton>
-                    <Typography
-                        variant="h5"
-                        component="h1"
-                        sx={{ fontWeight: 600 }}
-                    >
-                        {t("inventory.inventories")}
-                    </Typography>
-                </Box>
-
-                <Button
-                    variant="contained"
-                    startIcon={<Add />}
-                    onClick={handleCreateInventory}
-                    sx={{ fontWeight: 600 }}
-                >
-                    {t("common.create")}
-                </Button>
-            </Box>
+        <>
+            <PageHeadActionBar
+                title={t("inventory.inventories")}
+                directActions={[
+                    { icon: <Add />, onClick: handleCreateInventory },
+                ]}
+                menuActions={[]}
+            />
+            <Container maxWidth="sm" sx={pageContainerSx}>
             {isLoading && (
                 <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
                     <CircularProgress />
@@ -178,6 +150,7 @@ export const InventoriesPage = () => {
                 onDelete={handleDeleteInventory}
                 isDeleting={deleteInventoryMutation.isPending}
             />
-        </Container>
+            </Container>
+        </>
     );
 };

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx
@@ -89,6 +89,7 @@ export const InventoriesPage = () => {
         <>
             <PageHeadActionBar
                 title={t("inventory.inventories")}
+                section="inventory"
                 directActions={[
                     { icon: <Add />, onClick: handleCreateInventory },
                 ]}

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx
@@ -95,61 +95,67 @@ export const InventoriesPage = () => {
                 menuActions={[]}
             />
             <Container maxWidth="sm" sx={pageContainerSx}>
-            {isLoading && (
-                <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
-                    <CircularProgress />
-                </Box>
-            )}
-            {error && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                    {t("inventory.failedToLoadInventories")}
-                </Alert>
-            )}
-            {inventories && inventories.length === 0 && !isLoading && (
-                <Card elevation={1} sx={{ textAlign: "center", py: 4 }}>
-                    <CardContent>
-                        <Typography variant="h6" gutterBottom>
-                            {t("inventory.noInventoriesYet")}
-                        </Typography>
-                        <Typography
-                            variant="body2"
-                            sx={{
-                                color: "text.secondary",
-                                mb: 3,
-                            }}
-                        >
-                            {t("inventory.createFirstInventory")}
-                        </Typography>
-                        <Button
-                            variant="contained"
-                            startIcon={<Add />}
-                            onClick={handleCreateInventory}
-                            sx={{ fontWeight: 600 }}
-                        >
-                            {t("inventory.createYourFirstInventory")}
-                        </Button>
-                    </CardContent>
-                </Card>
-            )}
-            {inventories && inventories.length > 0 && (
-                <Stack spacing={2}>
-                    {inventories.map((inventory) => (
-                        <InventorySummaryCard
-                            key={inventory.id}
-                            inventory={inventory}
-                            onClick={handleInventoryClick}
-                            onMenuOpen={handleMenuOpen}
-                            menuDisabled={deleteInventoryMutation.isPending}
-                        />
-                    ))}
-                </Stack>
-            )}
-            <InventoryActionsMenu
-                anchorEl={anchorEl}
-                onClose={handleMenuClose}
-                onDelete={handleDeleteInventory}
-                isDeleting={deleteInventoryMutation.isPending}
-            />
+                {isLoading && (
+                    <Box
+                        sx={{
+                            display: "flex",
+                            justifyContent: "center",
+                            py: 4,
+                        }}
+                    >
+                        <CircularProgress />
+                    </Box>
+                )}
+                {error && (
+                    <Alert severity="error" sx={{ mb: 3 }}>
+                        {t("inventory.failedToLoadInventories")}
+                    </Alert>
+                )}
+                {inventories && inventories.length === 0 && !isLoading && (
+                    <Card elevation={1} sx={{ textAlign: "center", py: 4 }}>
+                        <CardContent>
+                            <Typography variant="h6" gutterBottom>
+                                {t("inventory.noInventoriesYet")}
+                            </Typography>
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    color: "text.secondary",
+                                    mb: 3,
+                                }}
+                            >
+                                {t("inventory.createFirstInventory")}
+                            </Typography>
+                            <Button
+                                variant="contained"
+                                startIcon={<Add />}
+                                onClick={handleCreateInventory}
+                                sx={{ fontWeight: 600 }}
+                            >
+                                {t("inventory.createYourFirstInventory")}
+                            </Button>
+                        </CardContent>
+                    </Card>
+                )}
+                {inventories && inventories.length > 0 && (
+                    <Stack spacing={2}>
+                        {inventories.map((inventory) => (
+                            <InventorySummaryCard
+                                key={inventory.id}
+                                inventory={inventory}
+                                onClick={handleInventoryClick}
+                                onMenuOpen={handleMenuOpen}
+                                menuDisabled={deleteInventoryMutation.isPending}
+                            />
+                        ))}
+                    </Stack>
+                )}
+                <InventoryActionsMenu
+                    anchorEl={anchorEl}
+                    onClose={handleMenuClose}
+                    onDelete={handleDeleteInventory}
+                    isDeleting={deleteInventoryMutation.isPending}
+                />
             </Container>
         </>
     );

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx
@@ -69,8 +69,6 @@ export const InventoriesPage = () => {
         handleMenuClose();
     };
 
-    const handleEditInventory = () => handleMenuClose();
-
     if (!householdId) {
         return (
             <Container maxWidth="sm" sx={pageContainerSx}>
@@ -177,7 +175,6 @@ export const InventoriesPage = () => {
             <InventoryActionsMenu
                 anchorEl={anchorEl}
                 onClose={handleMenuClose}
-                onEdit={handleEditInventory}
                 onDelete={handleDeleteInventory}
                 isDeleting={deleteInventoryMutation.isPending}
             />

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryEditPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryEditPage.tsx
@@ -1,19 +1,12 @@
-import { ArrowBack, Delete, MoreVert } from "@mui/icons-material";
-import {
-    Alert,
-    Box,
-    Container,
-    IconButton,
-    ListItemIcon,
-    ListItemText,
-    Menu,
-    MenuItem,
-    Skeleton,
-    Typography,
-} from "@mui/material";
-import { useParams, useRouter } from "@tanstack/react-router";
+import { Delete } from "@mui/icons-material";
+import { Alert, Box, Container, Skeleton } from "@mui/material";
+import { useParams } from "@tanstack/react-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+    PageHeadActionBar,
+    type HeadNavigationAction,
+} from "../../../components/shared/PageHeadActionBar";
 import { pageContainerSx } from "../../../theme";
 import { useCurrentHouseholdWithDetails } from "../../me/activeHousehold/useCurrentHouseholdWithDetails";
 import { DeleteInventoryConfirmDialog } from "../components/DeleteInventoryConfirmDialog";
@@ -22,7 +15,6 @@ import { InventorySettingsCard } from "../components/InventorySettingsCard";
 import { useInventory } from "../useInventory";
 
 export const InventoryEditPage = () => {
-    const router = useRouter();
     const { inventoryId } = useParams({
         from: "/inventories/$inventoryId/edit",
     });
@@ -30,7 +22,6 @@ export const InventoryEditPage = () => {
     const inventoryIdNum = parseInt(inventoryId, 10);
 
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-    const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
 
     const {
         currentHousehold,
@@ -50,14 +41,7 @@ export const InventoryEditPage = () => {
         hasActiveHousehold && !isNaN(inventoryIdNum),
     );
 
-    const handleBack = () => router.history.back();
-    const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
-        setMenuAnchor(event.currentTarget);
-    const handleMenuClose = () => setMenuAnchor(null);
-    const handleDeleteClick = () => {
-        setDeleteDialogOpen(true);
-        handleMenuClose();
-    };
+    const handleDeleteClick = () => setDeleteDialogOpen(true);
 
     const isLoading = householdLoading || inventoryLoading;
     const error = householdError || inventoryError;
@@ -110,90 +94,45 @@ export const InventoryEditPage = () => {
 
     const inventoryName = inventory.name || t("inventory.untitledInventory");
 
+    const menuActions: HeadNavigationAction[] = [
+        {
+            text: t("inventory.deleteInventory"),
+            icon: <Delete fontSize="small" />,
+            onClick: handleDeleteClick,
+        },
+    ];
+
     return (
-        <Container maxWidth="md" sx={pageContainerSx}>
-            <Box
-                sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: { xs: 1, sm: 2 },
-                    mb: { xs: 2, sm: 3 },
-                }}
-            >
-                <IconButton onClick={handleBack}>
-                    <ArrowBack />
-                </IconButton>
-
-                <Typography
-                    variant="h5"
-                    component="h1"
-                    sx={{ fontWeight: 600, flexGrow: 1 }}
-                >
-                    {t("inventory.editInventory")}
-                </Typography>
-
-                <IconButton
-                    onClick={handleMenuClick}
-                    size="small"
-                    sx={{
-                        bgcolor: "background.paper",
-                        border: 1,
-                        borderColor: "divider",
-                        "&:hover": { bgcolor: "action.hover" },
-                    }}
-                >
-                    <MoreVert fontSize="small" />
-                </IconButton>
-            </Box>
-
-            <EditInventoryForm
-                householdId={householdId}
-                inventory={inventory}
+        <>
+            <PageHeadActionBar
+                title={t("inventory.editInventory")}
+                maxWidth="md"
+                directActions={[]}
+                menuActions={menuActions}
             />
-
-            {inventory.id && (
-                <InventorySettingsCard
+            <Container maxWidth="md" sx={pageContainerSx}>
+                <EditInventoryForm
                     householdId={householdId}
-                    inventoryId={inventory.id}
+                    inventory={inventory}
                 />
-            )}
 
-            <Menu
-                anchorEl={menuAnchor}
-                open={Boolean(menuAnchor)}
-                onClose={handleMenuClose}
-                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-                transformOrigin={{ vertical: "top", horizontal: "right" }}
-                elevation={4}
-                slotProps={{ paper: { sx: { minWidth: 200, mt: 1 } } }}
-            >
-                <MenuItem
-                    onClick={handleDeleteClick}
-                    sx={{
-                        color: "error.main",
-                        py: 1.5,
-                        "&:hover": {
-                            bgcolor: "error.light",
-                            color: "error.contrastText",
-                        },
-                    }}
-                >
-                    <ListItemIcon>
-                        <Delete fontSize="small" color="error" />
-                    </ListItemIcon>
-                    <ListItemText primary={t("inventory.deleteInventory")} />
-                </MenuItem>
-            </Menu>
+                {inventory.id && (
+                    <InventorySettingsCard
+                        householdId={householdId}
+                        inventoryId={inventory.id}
+                    />
+                )}
 
-            {inventory.id && (
-                <DeleteInventoryConfirmDialog
-                    open={deleteDialogOpen}
-                    onClose={() => setDeleteDialogOpen(false)}
-                    householdId={householdId}
-                    inventoryId={inventory.id}
-                    inventoryName={inventoryName}
-                />
-            )}
-        </Container>
+                {inventory.id && (
+                    <DeleteInventoryConfirmDialog
+                        open={deleteDialogOpen}
+                        onClose={() => setDeleteDialogOpen(false)}
+                        householdId={householdId}
+                        inventoryId={inventory.id}
+                        inventoryName={inventoryName}
+                    />
+                )}
+            </Container>
+        </>
     );
 };

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryEditPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryEditPage.tsx
@@ -97,8 +97,9 @@ export const InventoryEditPage = () => {
     const menuActions: HeadNavigationAction[] = [
         {
             text: t("inventory.deleteInventory"),
-            icon: <Delete fontSize="small" />,
+            icon: <Delete fontSize="small" color="error" />,
             onClick: handleDeleteClick,
+            color: "error",
         },
     ];
 

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryEditPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryEditPage.tsx
@@ -107,6 +107,7 @@ export const InventoryEditPage = () => {
         <>
             <PageHeadActionBar
                 title={t("inventory.editInventory")}
+                section="inventory"
                 maxWidth="md"
                 directActions={[]}
                 menuActions={menuActions}

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryViewPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryViewPage.tsx
@@ -203,6 +203,7 @@ export const InventoryViewPage = () => {
             <PageHeadActionBar
                 title={inventory.name || t("inventory.untitledInventory")}
                 subtitle={inventory.description || undefined}
+                section="inventory"
                 directActions={directActions}
                 menuActions={menuActions}
             />

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/components/ListActionsMenu.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/components/ListActionsMenu.tsx
@@ -1,11 +1,10 @@
-import { Delete, Edit } from "@mui/icons-material";
+import { Delete } from "@mui/icons-material";
 import { Menu, MenuItem } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 interface ListActionsMenuProps {
     anchorEl: HTMLElement | null;
     onClose: () => void;
-    onEdit: () => void;
     onDelete: () => void;
     isDeleting?: boolean;
 }
@@ -13,7 +12,6 @@ interface ListActionsMenuProps {
 export const ListActionsMenu = ({
     anchorEl,
     onClose,
-    onEdit,
     onDelete,
     isDeleting = false,
 }: ListActionsMenuProps) => {
@@ -27,10 +25,6 @@ export const ListActionsMenu = ({
             elevation={4}
             slotProps={{ paper: { sx: { minWidth: 160 } } }}
         >
-            <MenuItem onClick={onEdit} disabled>
-                <Edit fontSize="small" sx={{ mr: 1 }} />
-                {t("common.edit")}
-            </MenuItem>
             <MenuItem
                 onClick={onDelete}
                 disabled={isDeleting}

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListItemContent.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListItemContent.tsx
@@ -55,9 +55,6 @@ export function ListItemContent({ item, onEditQuantity }: Props) {
                             onClick={onEditQuantity}
                             sx={{
                                 height: 20,
-                                textDecoration: item.status
-                                    ? "line-through"
-                                    : "none",
                             }}
                         />
                     </Box>

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListEditPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListEditPage.tsx
@@ -94,8 +94,9 @@ export const ListEditPage = () => {
     const menuActions: HeadNavigationAction[] = [
         {
             text: t("lists.deleteList"),
-            icon: <Delete fontSize="small" />,
+            icon: <Delete fontSize="small" color="error" />,
             onClick: handleDeleteClick,
+            color: "error",
         },
     ];
 

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListEditPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListEditPage.tsx
@@ -1,19 +1,12 @@
-import { ArrowBack, Delete, MoreVert } from "@mui/icons-material";
-import {
-    Alert,
-    Box,
-    Container,
-    IconButton,
-    ListItemIcon,
-    ListItemText,
-    Menu,
-    MenuItem,
-    Skeleton,
-    Typography,
-} from "@mui/material";
-import { useParams, useRouter } from "@tanstack/react-router";
+import { Delete } from "@mui/icons-material";
+import { Alert, Box, Container, Skeleton } from "@mui/material";
+import { useParams } from "@tanstack/react-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+    PageHeadActionBar,
+    type HeadNavigationAction,
+} from "../../../components/shared/PageHeadActionBar";
 import { pageContainerSx } from "../../../theme";
 import { useCurrentHouseholdWithDetails } from "../../me/activeHousehold/useCurrentHouseholdWithDetails";
 import { DeleteListConfirmDialog } from "../components/DeleteListConfirmDialog";
@@ -21,13 +14,11 @@ import { EditListForm } from "../components/EditListForm";
 import { useList } from "../useList";
 
 export const ListEditPage = () => {
-    const router = useRouter();
     const { listId } = useParams({ from: "/lists/$listId/edit" });
     const { t } = useTranslation();
     const listIdNum = parseInt(listId, 10);
 
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-    const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
 
     const {
         currentHousehold,
@@ -47,14 +38,7 @@ export const ListEditPage = () => {
         hasActiveHousehold && !isNaN(listIdNum),
     );
 
-    const handleBack = () => router.history.back();
-    const handleMenuClick = (event: React.MouseEvent<HTMLElement>) =>
-        setMenuAnchor(event.currentTarget);
-    const handleMenuClose = () => setMenuAnchor(null);
-    const handleDeleteClick = () => {
-        setDeleteDialogOpen(true);
-        handleMenuClose();
-    };
+    const handleDeleteClick = () => setDeleteDialogOpen(true);
 
     const isLoading = householdLoading || listLoading;
     const error = householdError || listError;
@@ -107,80 +91,35 @@ export const ListEditPage = () => {
 
     const listName = list.name || t("lists.untitledList");
 
+    const menuActions: HeadNavigationAction[] = [
+        {
+            text: t("lists.deleteList"),
+            icon: <Delete fontSize="small" />,
+            onClick: handleDeleteClick,
+        },
+    ];
+
     return (
-        <Container maxWidth="md" sx={pageContainerSx}>
-            <Box
-                sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: { xs: 1, sm: 2 },
-                    mb: { xs: 2, sm: 3 },
-                }}
-            >
-                <IconButton onClick={handleBack}>
-                    <ArrowBack />
-                </IconButton>
+        <>
+            <PageHeadActionBar
+                title={t("lists.editList")}
+                maxWidth="md"
+                directActions={[]}
+                menuActions={menuActions}
+            />
+            <Container maxWidth="md" sx={pageContainerSx}>
+                <EditListForm householdId={householdId} list={list} />
 
-                <Typography
-                    variant="h5"
-                    component="h1"
-                    sx={{ fontWeight: 600, flexGrow: 1 }}
-                >
-                    {t("lists.editList")}
-                </Typography>
-
-                <IconButton
-                    onClick={handleMenuClick}
-                    size="small"
-                    sx={{
-                        bgcolor: "background.paper",
-                        border: 1,
-                        borderColor: "divider",
-                        "&:hover": { bgcolor: "action.hover" },
-                    }}
-                >
-                    <MoreVert fontSize="small" />
-                </IconButton>
-            </Box>
-
-            <EditListForm householdId={householdId} list={list} />
-
-            <Menu
-                anchorEl={menuAnchor}
-                open={Boolean(menuAnchor)}
-                onClose={handleMenuClose}
-                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-                transformOrigin={{ vertical: "top", horizontal: "right" }}
-                elevation={4}
-                slotProps={{ paper: { sx: { minWidth: 200, mt: 1 } } }}
-            >
-                <MenuItem
-                    onClick={handleDeleteClick}
-                    sx={{
-                        color: "error.main",
-                        py: 1.5,
-                        "&:hover": {
-                            bgcolor: "error.light",
-                            color: "error.contrastText",
-                        },
-                    }}
-                >
-                    <ListItemIcon>
-                        <Delete fontSize="small" color="error" />
-                    </ListItemIcon>
-                    <ListItemText primary={t("lists.deleteList")} />
-                </MenuItem>
-            </Menu>
-
-            {list.id && (
-                <DeleteListConfirmDialog
-                    open={deleteDialogOpen}
-                    onClose={() => setDeleteDialogOpen(false)}
-                    householdId={householdId}
-                    listId={list.id}
-                    listName={listName}
-                />
-            )}
-        </Container>
+                {list.id && (
+                    <DeleteListConfirmDialog
+                        open={deleteDialogOpen}
+                        onClose={() => setDeleteDialogOpen(false)}
+                        householdId={householdId}
+                        listId={list.id}
+                        listName={listName}
+                    />
+                )}
+            </Container>
+        </>
     );
 };

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListEditPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListEditPage.tsx
@@ -104,6 +104,7 @@ export const ListEditPage = () => {
         <>
             <PageHeadActionBar
                 title={t("lists.editList")}
+                section="lists"
                 maxWidth="md"
                 directActions={[]}
                 menuActions={menuActions}

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListViewPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListViewPage.tsx
@@ -227,6 +227,7 @@ export const ListViewPage = () => {
             <PageHeadActionBar
                 title={list.name || t("lists.untitledList")}
                 subtitle={list.description || undefined}
+                section="lists"
                 directActions={directActions}
                 menuActions={menuActions}
             />

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx
@@ -92,61 +92,67 @@ export const ListsPage = () => {
                 menuActions={[]}
             />
             <Container maxWidth="sm" sx={pageContainerSx}>
-            {isLoading && (
-                <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
-                    <CircularProgress />
-                </Box>
-            )}
-            {error && (
-                <Alert severity="error" sx={{ mb: 3 }}>
-                    {t("lists.failedToLoadLists")}
-                </Alert>
-            )}
-            {lists && lists.length === 0 && !isLoading && (
-                <Card elevation={1} sx={{ textAlign: "center", py: 4 }}>
-                    <CardContent>
-                        <Typography variant="h6" gutterBottom>
-                            {t("lists.noListsYet")}
-                        </Typography>
-                        <Typography
-                            variant="body2"
-                            sx={{
-                                color: "text.secondary",
-                                mb: 3,
-                            }}
-                        >
-                            {t("lists.createFirstShoppingList")}
-                        </Typography>
-                        <Button
-                            variant="contained"
-                            startIcon={<Add />}
-                            onClick={handleCreateList}
-                            sx={{ fontWeight: 600 }}
-                        >
-                            {t("lists.createYourFirstList")}
-                        </Button>
-                    </CardContent>
-                </Card>
-            )}
-            {lists && lists.length > 0 && (
-                <Stack spacing={2}>
-                    {lists.map((list) => (
-                        <ListSummaryCard
-                            key={list.id}
-                            list={list}
-                            onClick={handleListClick}
-                            onMenuOpen={handleMenuOpen}
-                            menuDisabled={deleteListMutation.isPending}
-                        />
-                    ))}
-                </Stack>
-            )}
-            <ListActionsMenu
-                anchorEl={anchorEl}
-                onClose={handleMenuClose}
-                onDelete={handleDeleteList}
-                isDeleting={deleteListMutation.isPending}
-            />
+                {isLoading && (
+                    <Box
+                        sx={{
+                            display: "flex",
+                            justifyContent: "center",
+                            py: 4,
+                        }}
+                    >
+                        <CircularProgress />
+                    </Box>
+                )}
+                {error && (
+                    <Alert severity="error" sx={{ mb: 3 }}>
+                        {t("lists.failedToLoadLists")}
+                    </Alert>
+                )}
+                {lists && lists.length === 0 && !isLoading && (
+                    <Card elevation={1} sx={{ textAlign: "center", py: 4 }}>
+                        <CardContent>
+                            <Typography variant="h6" gutterBottom>
+                                {t("lists.noListsYet")}
+                            </Typography>
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    color: "text.secondary",
+                                    mb: 3,
+                                }}
+                            >
+                                {t("lists.createFirstShoppingList")}
+                            </Typography>
+                            <Button
+                                variant="contained"
+                                startIcon={<Add />}
+                                onClick={handleCreateList}
+                                sx={{ fontWeight: 600 }}
+                            >
+                                {t("lists.createYourFirstList")}
+                            </Button>
+                        </CardContent>
+                    </Card>
+                )}
+                {lists && lists.length > 0 && (
+                    <Stack spacing={2}>
+                        {lists.map((list) => (
+                            <ListSummaryCard
+                                key={list.id}
+                                list={list}
+                                onClick={handleListClick}
+                                onMenuOpen={handleMenuOpen}
+                                menuDisabled={deleteListMutation.isPending}
+                            />
+                        ))}
+                    </Stack>
+                )}
+                <ListActionsMenu
+                    anchorEl={anchorEl}
+                    onClose={handleMenuClose}
+                    onDelete={handleDeleteList}
+                    isDeleting={deleteListMutation.isPending}
+                />
             </Container>
         </>
     );

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx
@@ -88,6 +88,7 @@ export const ListsPage = () => {
         <>
             <PageHeadActionBar
                 title={t("lists.shoppingLists")}
+                section="lists"
                 directActions={[{ icon: <Add />, onClick: handleCreateList }]}
                 menuActions={[]}
             />

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx
@@ -68,8 +68,6 @@ export const ListsPage = () => {
         handleMenuClose();
     };
 
-    const handleEditList = () => handleMenuClose();
-
     if (!householdId) {
         return (
             <Container maxWidth="sm" sx={pageContainerSx}>
@@ -176,7 +174,6 @@ export const ListsPage = () => {
             <ListActionsMenu
                 anchorEl={anchorEl}
                 onClose={handleMenuClose}
-                onEdit={handleEditList}
                 onDelete={handleDeleteList}
                 isDeleting={deleteListMutation.isPending}
             />

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx
@@ -1,4 +1,4 @@
-import { Add, ArrowBack } from "@mui/icons-material";
+import { Add } from "@mui/icons-material";
 import {
     Alert,
     Box,
@@ -7,7 +7,6 @@ import {
     CardContent,
     CircularProgress,
     Container,
-    IconButton,
     Stack,
     Typography,
 } from "@mui/material";
@@ -16,6 +15,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ListResponse } from "../../../lib/api";
 import { pageContainerSx } from "../../../theme";
+import { PageHeadActionBar } from "../../../components/shared/PageHeadActionBar";
 import { useCurrentHousehold } from "../../me/activeHousehold/useCurrentHousehold";
 import { ListActionsMenu } from "../components/ListActionsMenu";
 import { ListSummaryCard } from "../components/ListSummaryCard";
@@ -85,43 +85,13 @@ export const ListsPage = () => {
     }
 
     return (
-        <Container maxWidth="sm" sx={pageContainerSx}>
-            <Box
-                sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    mb: { xs: 2, sm: 3 },
-                }}
-            >
-                <Box
-                    sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: { xs: 1, sm: 2 },
-                    }}
-                >
-                    <IconButton onClick={handleBack}>
-                        <ArrowBack />
-                    </IconButton>
-                    <Typography
-                        variant="h5"
-                        component="h1"
-                        sx={{ fontWeight: 600 }}
-                    >
-                        {t("lists.shoppingLists")}
-                    </Typography>
-                </Box>
-
-                <Button
-                    variant="contained"
-                    startIcon={<Add />}
-                    onClick={handleCreateList}
-                    sx={{ fontWeight: 600 }}
-                >
-                    {t("common.create")}
-                </Button>
-            </Box>
+        <>
+            <PageHeadActionBar
+                title={t("lists.shoppingLists")}
+                directActions={[{ icon: <Add />, onClick: handleCreateList }]}
+                menuActions={[]}
+            />
+            <Container maxWidth="sm" sx={pageContainerSx}>
             {isLoading && (
                 <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
                     <CircularProgress />
@@ -177,6 +147,7 @@ export const ListsPage = () => {
                 onDelete={handleDeleteList}
                 isDeleting={deleteListMutation.isPending}
             />
-        </Container>
+            </Container>
+        </>
     );
 };

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/promote/PromoteBar.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/promote/PromoteBar.tsx
@@ -1,5 +1,6 @@
 import { Inventory2Outlined } from "@mui/icons-material";
 import { Button, Paper, Typography } from "@mui/material";
+import { alpha } from "@mui/material/styles";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { usePromotableForList } from "./promotableStore";
@@ -41,18 +42,26 @@ export const PromoteBar = ({ householdId, listId }: PromoteBarProps) => {
                     display: "flex",
                     alignItems: "center",
                     gap: 1,
-                    bgcolor: "primary.main",
-                    color: "primary.contrastText",
+                    bgcolor: (theme) => alpha(theme.palette.primary.main, 0.15),
+                    color: "text.primary",
+                    border: "1px solid",
+                    borderColor: (theme) =>
+                        alpha(theme.palette.primary.main, 0.3),
+                    borderLeft: "3px solid",
+                    borderLeftColor: "primary.main",
                 }}
             >
-                <Inventory2Outlined fontSize="small" />
+                <Inventory2Outlined
+                    fontSize="small"
+                    sx={{ color: "primary.main" }}
+                />
                 <Typography variant="body2" sx={{ flex: 1 }}>
                     {t("promote.barReady", { count: entries.length })}
                 </Typography>
                 <Button
                     size="small"
                     variant="contained"
-                    color="secondary"
+                    color="primary"
                     data-testid="promote-bar-review"
                     onClick={() => setOpen(true)}
                 >

--- a/Application/Frigorino.Web/ClientApp/src/features/settings/pages/UserSettingsPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/settings/pages/UserSettingsPage.tsx
@@ -175,117 +175,124 @@ export function UserSettingsPage() {
                 menuActions={[]}
             />
             <Container maxWidth="sm" sx={pageContainerSx}>
-
-            <Card elevation={2}>
-                <CardContent>
-                    <TextField
-                        select
-                        fullWidth
-                        size="small"
-                        data-testid="settings-language-select"
-                        label={t("settings.language")}
-                        helperText={t("settings.languageHelp")}
-                        value={currentLanguage}
-                        disabled={isLoading || updateSettings.isPending}
-                        onChange={(e) => handleLanguageChange(e.target.value)}
-                        slotProps={{
-                            htmlInput: {
-                                "data-testid": "settings-language-value",
-                            },
-                        }}
-                    >
-                        {LANGUAGES.map((lang) => (
-                            <MenuItem
-                                key={lang.code}
-                                value={lang.code}
-                                data-testid={`settings-language-option-${lang.code}`}
-                            >
-                                {lang.label}
-                            </MenuItem>
-                        ))}
-                    </TextField>
-                </CardContent>
-            </Card>
-
-            <Card elevation={2} sx={{ mt: { xs: 2, sm: 3 } }}>
-                <CardContent>
-                    <Typography variant="h6" sx={{ mb: 1 }}>
-                        {t("settings.notifications")}
-                    </Typography>
-
-                    {iosHint && (
-                        <Alert
-                            severity="info"
-                            sx={{ mb: 2 }}
-                            data-testid="settings-ios-install-hint"
-                        >
-                            {t("settings.notificationsIosHint")}
-                        </Alert>
-                    )}
-
-                    {supported && permissionBlocked && (
-                        <Alert
-                            severity="warning"
-                            sx={{ mb: 2 }}
-                            data-testid="settings-notifications-blocked-hint"
-                        >
-                            {t("settings.notificationsBlockedHint")}
-                        </Alert>
-                    )}
-
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                        <FormControlLabel
-                            control={
-                                <Switch
-                                    data-testid="settings-notifications-switch"
-                                    checked={effectiveEnabled}
-                                    disabled={
-                                        !supported ||
-                                        permissionBlocked ||
-                                        togglingPush ||
-                                        updateNotifications.isPending
-                                    }
-                                    onChange={(e) =>
-                                        handleToggleNotifications(
-                                            e.target.checked,
-                                        )
-                                    }
-                                />
-                            }
-                            label={t("settings.notificationsEnable")}
-                        />
-                        {togglingPush && (
-                            <CircularProgress
-                                size={18}
-                                data-testid="settings-notifications-spinner"
-                            />
-                        )}
-                    </Box>
-
-                    {effectiveEnabled && (
+                <Card elevation={2}>
+                    <CardContent>
                         <TextField
-                            type="number"
+                            select
                             fullWidth
                             size="small"
-                            sx={{ mt: 1 }}
-                            label={t("settings.notificationsLeadDays")}
-                            helperText={t("settings.notificationsLeadHelp")}
-                            value={leadDays}
-                            disabled={updateNotifications.isPending}
-                            onChange={(e) => setLeadDays(e.target.value)}
-                            onBlur={handleLeadDaysBlur}
+                            data-testid="settings-language-select"
+                            label={t("settings.language")}
+                            helperText={t("settings.languageHelp")}
+                            value={currentLanguage}
+                            disabled={isLoading || updateSettings.isPending}
+                            onChange={(e) =>
+                                handleLanguageChange(e.target.value)
+                            }
                             slotProps={{
                                 htmlInput: {
-                                    min: 0,
-                                    max: 365,
-                                    "data-testid":
-                                        "settings-notifications-lead-input",
+                                    "data-testid": "settings-language-value",
                                 },
                             }}
-                        />
-                    )}
-                </CardContent>
-            </Card>
+                        >
+                            {LANGUAGES.map((lang) => (
+                                <MenuItem
+                                    key={lang.code}
+                                    value={lang.code}
+                                    data-testid={`settings-language-option-${lang.code}`}
+                                >
+                                    {lang.label}
+                                </MenuItem>
+                            ))}
+                        </TextField>
+                    </CardContent>
+                </Card>
+
+                <Card elevation={2} sx={{ mt: { xs: 2, sm: 3 } }}>
+                    <CardContent>
+                        <Typography variant="h6" sx={{ mb: 1 }}>
+                            {t("settings.notifications")}
+                        </Typography>
+
+                        {iosHint && (
+                            <Alert
+                                severity="info"
+                                sx={{ mb: 2 }}
+                                data-testid="settings-ios-install-hint"
+                            >
+                                {t("settings.notificationsIosHint")}
+                            </Alert>
+                        )}
+
+                        {supported && permissionBlocked && (
+                            <Alert
+                                severity="warning"
+                                sx={{ mb: 2 }}
+                                data-testid="settings-notifications-blocked-hint"
+                            >
+                                {t("settings.notificationsBlockedHint")}
+                            </Alert>
+                        )}
+
+                        <Box
+                            sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 1,
+                            }}
+                        >
+                            <FormControlLabel
+                                control={
+                                    <Switch
+                                        data-testid="settings-notifications-switch"
+                                        checked={effectiveEnabled}
+                                        disabled={
+                                            !supported ||
+                                            permissionBlocked ||
+                                            togglingPush ||
+                                            updateNotifications.isPending
+                                        }
+                                        onChange={(e) =>
+                                            handleToggleNotifications(
+                                                e.target.checked,
+                                            )
+                                        }
+                                    />
+                                }
+                                label={t("settings.notificationsEnable")}
+                            />
+                            {togglingPush && (
+                                <CircularProgress
+                                    size={18}
+                                    data-testid="settings-notifications-spinner"
+                                />
+                            )}
+                        </Box>
+
+                        {effectiveEnabled && (
+                            <TextField
+                                type="number"
+                                fullWidth
+                                size="small"
+                                sx={{ mt: 1 }}
+                                label={t("settings.notificationsLeadDays")}
+                                helperText={t("settings.notificationsLeadHelp")}
+                                value={leadDays}
+                                disabled={updateNotifications.isPending}
+                                onChange={(e) => setLeadDays(e.target.value)}
+                                onBlur={handleLeadDaysBlur}
+                                slotProps={{
+                                    htmlInput: {
+                                        min: 0,
+                                        max: 365,
+                                        "data-testid":
+                                            "settings-notifications-lead-input",
+                                    },
+                                }}
+                            />
+                        )}
+                    </CardContent>
+                </Card>
             </Container>
         </>
     );

--- a/Application/Frigorino.Web/ClientApp/src/features/settings/pages/UserSettingsPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/settings/pages/UserSettingsPage.tsx
@@ -23,6 +23,7 @@ import {
     isIosNeedingInstall,
     pushSupported,
 } from "../../../common/pushNotifications";
+import { PageHeadActionBar } from "../../../components/shared/PageHeadActionBar";
 import { pageContainerSx } from "../../../theme";
 import { useUpdateUserNotificationSettings } from "../useUpdateUserNotificationSettings";
 import { useUpdateUserSettings } from "../useUpdateUserSettings";
@@ -167,10 +168,13 @@ export function UserSettingsPage() {
     const effectiveEnabled = enabled && permissionGranted;
 
     return (
-        <Container maxWidth="sm" sx={pageContainerSx}>
-            <Typography variant="h5" sx={{ mb: { xs: 2, sm: 3 } }}>
-                {t("settings.userSettings")}
-            </Typography>
+        <>
+            <PageHeadActionBar
+                title={t("settings.userSettings")}
+                directActions={[]}
+                menuActions={[]}
+            />
+            <Container maxWidth="sm" sx={pageContainerSx}>
 
             <Card elevation={2}>
                 <CardContent>
@@ -282,6 +286,7 @@ export function UserSettingsPage() {
                     )}
                 </CardContent>
             </Card>
-        </Container>
+            </Container>
+        </>
     );
 }

--- a/Application/Frigorino.Web/ClientApp/src/lib/api/types.gen.ts
+++ b/Application/Frigorino.Web/ClientApp/src/lib/api/types.gen.ts
@@ -97,6 +97,7 @@ export type InventoryResponse = {
     createdByUser: InventoryCreatorResponse;
     totalItems: number;
     expiringItems: number;
+    earliestExpiryDate: null | string;
 };
 
 export type InventorySettingsResponse = {

--- a/Application/Frigorino.Web/ClientApp/src/lib/openapi.json
+++ b/Application/Frigorino.Web/ClientApp/src/lib/openapi.json
@@ -2568,7 +2568,8 @@
           "updatedAt",
           "createdByUser",
           "totalItems",
-          "expiringItems"
+          "expiringItems",
+          "earliestExpiryDate"
         ],
         "type": "object",
         "properties": {
@@ -2607,6 +2608,13 @@
           "expiringItems": {
             "type": "integer",
             "format": "int32"
+          },
+          "earliestExpiryDate": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date"
           }
         }
       },

--- a/Application/Frigorino.Web/ClientApp/src/theme.ts
+++ b/Application/Frigorino.Web/ClientApp/src/theme.ts
@@ -20,6 +20,19 @@ export const appTheme = responsiveFontSizes(
     }),
 );
 
+// Section identity colors ("quiet identity": applied only to the small section
+// icon glyph for wayfinding — chrome stays neutral, and red/amber remain
+// reserved for expiry status. Inventory deliberately stays cool so it never
+// collides with the amber/red expiry chips shown on its own cards.
+export const sectionColors = {
+    household: "#5FA86F", // green — matches the brand identity in the picker
+    lists: "#5A92CB", // blue
+    inventory: "#4BA1A1", // teal
+    recipes: "#D18A77", // warm coral
+} as const;
+
+export type SectionKey = keyof typeof sectionColors;
+
 export const pageContainerSx = {
     py: { xs: 2, sm: 3 },
     px: { xs: 1, sm: 2 },

--- a/Application/Frigorino.Web/ClientApp/src/theme.ts
+++ b/Application/Frigorino.Web/ClientApp/src/theme.ts
@@ -2,7 +2,13 @@ import { createTheme, responsiveFontSizes } from "@mui/material/styles";
 
 export const appTheme = responsiveFontSizes(
     createTheme({
-        palette: { mode: "dark" },
+        palette: {
+            mode: "dark",
+            // Fresh-green primary suits a food/fridge app; used sparingly per direction A.
+            primary: { main: "#43A047" },
+            // Warm amber replaces the default clashing pink.
+            secondary: { main: "#FFB300" },
+        },
         shape: { borderRadius: 8 },
         components: {
             MuiButton: {

--- a/docs/superpowers/plans/2026-06-02-ux-alignment.md
+++ b/docs/superpowers/plans/2026-06-02-ux-alignment.md
@@ -1,0 +1,1290 @@
+# UX Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply visual direction "A — subtle & semantic" across the SPA: a real theme palette, a calmer Promote bar, clearer dashboard counts, a colored earliest-expiry chip on inventories, no strikethrough on checked items, and one standardized page header with consistent action placement.
+
+**Architecture:** Mostly surgical edits to existing React/MUI components plus one EF projection field. A shared `PageHeadActionBar` already exists and is used by the two "view" pages; the work standardizes the remaining pages onto it (extending it minimally to preserve test ids and support a wider container). One backend DTO gains an `EarliestExpiryDate` field via the existing EF projection; the TS client is regenerated from the OpenAPI spec.
+
+**Tech Stack:** React 19, MUI v7, TanStack Router/Query, TypeScript, i18next; .NET 10 minimal-API vertical slices, EF Core (Postgres), xUnit + FakeItEasy.
+
+**Conventions (read before starting):**
+- **No frontend test runner exists.** Frontend tasks verify with `npm run tsc` + `npm run lint` (run from `Application/Frigorino.Web/ClientApp/`). Only the backend task is TDD.
+- Run all `npm` commands from `Application/Frigorino.Web/ClientApp/`. Run `dotnet` from repo root.
+- Commit after every task. Keep each task build-green (tsc + lint pass).
+- C# brace style: always block `{}`. Never assert on translated text in tests.
+- Spec: `docs/superpowers/specs/2026-06-02-ux-alignment-design.md`.
+
+---
+
+## Phase A — Theme & quick wins
+
+### Task 1: Theme palette
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/theme.ts`
+
+- [ ] **Step 1: Add the palette**
+
+Replace the `createTheme({...})` call so it defines an explicit primary/secondary (today it relies on MUI dark defaults: light-blue primary + pink secondary). Full new file content:
+
+```ts
+import { createTheme, responsiveFontSizes } from "@mui/material/styles";
+
+export const appTheme = responsiveFontSizes(
+    createTheme({
+        palette: {
+            mode: "dark",
+            // Fresh-green primary suits a food/fridge app; used sparingly per direction A.
+            primary: { main: "#43A047" },
+            // Warm amber replaces the default clashing pink.
+            secondary: { main: "#FFB300" },
+        },
+        shape: { borderRadius: 8 },
+        components: {
+            MuiButton: {
+                styleOverrides: {
+                    root: { textTransform: "none" },
+                },
+            },
+        },
+    }),
+);
+
+export const pageContainerSx = {
+    py: { xs: 2, sm: 3 },
+    px: { xs: 1, sm: 2 },
+};
+```
+
+- [ ] **Step 2: Type-check & lint**
+
+Run (from `Application/Frigorino.Web/ClientApp/`): `npm run tsc && npm run lint`
+Expected: PASS (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/theme.ts
+git commit -m "feat(theme): add green/amber palette (direction A)"
+```
+
+---
+
+### Task 2: Promote bar — soft tinted banner
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/lists/promote/PromoteBar.tsx`
+
+- [ ] **Step 1: Restyle the Paper + button**
+
+Change the import line 2 to also import `alpha`:
+
+```tsx
+import { Button, Paper, Typography } from "@mui/material";
+import { alpha } from "@mui/material/styles";
+```
+
+Replace the `<Paper ...>` opening tag's `sx` (currently `bgcolor: "primary.main", color: "primary.contrastText"`) and the icon + button. The new `<Paper>` block (replacing lines 32–61) is:
+
+```tsx
+            <Paper
+                elevation={0}
+                data-testid="promote-bar"
+                data-count={entries.length}
+                sx={{
+                    mx: 3,
+                    mb: 1,
+                    px: 1.5,
+                    py: 1,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1,
+                    bgcolor: (theme) => alpha(theme.palette.primary.main, 0.15),
+                    color: "text.primary",
+                    border: "1px solid",
+                    borderColor: (theme) =>
+                        alpha(theme.palette.primary.main, 0.3),
+                    borderLeft: "3px solid",
+                    borderLeftColor: "primary.main",
+                }}
+            >
+                <Inventory2Outlined
+                    fontSize="small"
+                    sx={{ color: "primary.main" }}
+                />
+                <Typography variant="body2" sx={{ flex: 1 }}>
+                    {t("promote.barReady", { count: entries.length })}
+                </Typography>
+                <Button
+                    size="small"
+                    variant="contained"
+                    color="primary"
+                    data-testid="promote-bar-review"
+                    onClick={() => setOpen(true)}
+                >
+                    {t("promote.review")}
+                </Button>
+            </Paper>
+```
+
+(Key changes: tinted background + left accent instead of solid fill; icon tinted primary; button `color="secondary"` → `color="primary"`. The `data-testid`/`data-count` attributes are preserved.)
+
+- [ ] **Step 2: Type-check & lint**
+
+Run: `npm run tsc && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/features/lists/promote/PromoteBar.tsx
+git commit -m "feat(promote): calmer tinted promote bar (direction A)"
+```
+
+---
+
+### Task 3: Remove strikethrough from checked-item quantity chip
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListItemContent.tsx`
+
+Background: the only "checked" strikethrough in the app is on the quantity chip here (the item text has none; the row already greys out via `opacity: 0.7` in `SortableListItem`). Remove the chip's strikethrough entirely.
+
+- [ ] **Step 1: Drop the `textDecoration` rule**
+
+In the `<Chip ... sx={{ ... }}>` (lines 56–61), replace:
+
+```tsx
+                            sx={{
+                                height: 20,
+                                textDecoration: item.status
+                                    ? "line-through"
+                                    : "none",
+                            }}
+```
+
+with:
+
+```tsx
+                            sx={{
+                                height: 20,
+                            }}
+```
+
+- [ ] **Step 2: Type-check & lint**
+
+Run: `npm run tsc && npm run lint`
+Expected: PASS. (`item.status` is still used? No — confirm no now-unused vars; `item` is still used elsewhere, so no unused-import errors.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListItemContent.tsx
+git commit -m "fix(lists): remove strikethrough on checked-item quantity chip"
+```
+
+---
+
+## Phase B — Dashboard count clarity
+
+### Task 4: Shopping-list count = "open" (total in subtitle)
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx`
+- Modify: `Application/Frigorino.Web/ClientApp/public/locales/en/translation.json`
+- Modify: `Application/Frigorino.Web/ClientApp/public/locales/de/translation.json`
+
+Background: today the dashboard list row builds `count = "${checkedCount}/${uncheckedCount} Artikel"` and the card renders that same string **twice** (chip label + secondary line); the computed `status` is never shown. Fix: chip = open count, secondary line = total. "Open" = `uncheckedCount` (items not yet checked off); total = `uncheckedCount + checkedCount`.
+
+- [ ] **Step 1: Add translation keys**
+
+In `en/translation.json`, inside the `"dashboard"` object (currently has `items`/`articles`/`expiring`), add two keys:
+
+```json
+        "open": "open",
+        "itemsTotal": "items total",
+```
+
+In `de/translation.json`, inside `"dashboard"`, add:
+
+```json
+        "open": "offen",
+        "itemsTotal": "Artikel gesamt",
+```
+
+(Place them next to the existing `expiring` key; keep valid JSON — mind the trailing commas.)
+
+- [ ] **Step 2: Change the list mapping**
+
+In `WelcomePage.tsx`, replace the list `.map(...)` (lines 134–141):
+
+```tsx
+                  ? lists.map((list) => ({
+                        name: list.name || "Unnamed List",
+                        count: `${list.checkedCount}/${list.uncheckedCount} ${t("dashboard.articles")}`,
+                        status: new Date(list.createdAt!).toLocaleDateString(
+                            "de-DE",
+                        ),
+                        id: list.id,
+                    }))
+```
+
+with:
+
+```tsx
+                  ? lists.map((list) => ({
+                        name: list.name || "Unnamed List",
+                        count: `${list.uncheckedCount} ${t("dashboard.open")}`,
+                        status: `${list.uncheckedCount + list.checkedCount} ${t("dashboard.itemsTotal")}`,
+                        id: list.id,
+                    }))
+```
+
+- [ ] **Step 3: Render the subtitle from `status`, not `count`**
+
+In the card body, change the duplicated render (line 503):
+
+```tsx
+                                                        secondary={item.count}
+```
+
+to:
+
+```tsx
+                                                        secondary={item.status}
+```
+
+(This makes the chip show `count` and the subtitle show `status` for every collection — fixing the duplication. Inventory rows now show their existing "N expiring"/"current" status; recipe/empty/loading rows show their helper text.)
+
+- [ ] **Step 4: Type-check & lint**
+
+Run: `npm run tsc && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx Application/Frigorino.Web/ClientApp/public/locales/en/translation.json Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
+git commit -m "feat(dashboard): show open count + total instead of confusing duplicate"
+```
+
+---
+
+## Phase C — Inventory earliest-expiry chip
+
+### Task 5: Backend — add `EarliestExpiryDate` to `InventoryResponse`
+
+**Files:**
+- Modify: `Application/Frigorino.Features/Inventories/InventoryResponse.cs`
+- Test: `Application/Frigorino.Test/Features/InventoryResponseProjectionTests.cs` (create)
+
+The projection is an EF `Expression`; we test it by compiling it and applying it to in-memory entities (the entities are POCOs with public setters). Using `OrderBy().Select().FirstOrDefault()` (not `Min`) so LINQ-to-objects and EF SQL agree on the empty case (→ `null`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Application/Frigorino.Test/Features/InventoryResponseProjectionTests.cs`:
+
+```csharp
+using Frigorino.Domain.Entities;
+using Frigorino.Features.Inventories;
+
+namespace Frigorino.Test.Features
+{
+    public class InventoryResponseProjectionTests
+    {
+        private static Inventory BuildInventory(params InventoryItem[] items)
+        {
+            return new Inventory
+            {
+                Id = 1,
+                Name = "Fridge",
+                Description = null,
+                HouseholdId = 1,
+                CreatedByUser = new User
+                {
+                    ExternalId = "u1",
+                    Name = "Tester",
+                    Email = "t@example.com",
+                },
+                InventoryItems = items.ToList(),
+            };
+        }
+
+        [Fact]
+        public void EarliestExpiryDate_IsMinAmongActiveItemsWithDate()
+        {
+            var inventory = BuildInventory(
+                new InventoryItem { IsActive = true, ExpiryDate = new DateOnly(2026, 7, 1) },
+                new InventoryItem { IsActive = true, ExpiryDate = new DateOnly(2026, 6, 10) },
+                new InventoryItem { IsActive = true, ExpiryDate = null });
+
+            var result = InventoryResponse.ToProjection.Compile().Invoke(inventory);
+
+            Assert.Equal(new DateOnly(2026, 6, 10), result.EarliestExpiryDate);
+        }
+
+        [Fact]
+        public void EarliestExpiryDate_IgnoresInactiveItems()
+        {
+            var inventory = BuildInventory(
+                new InventoryItem { IsActive = false, ExpiryDate = new DateOnly(2026, 1, 1) },
+                new InventoryItem { IsActive = true, ExpiryDate = new DateOnly(2026, 6, 10) });
+
+            var result = InventoryResponse.ToProjection.Compile().Invoke(inventory);
+
+            Assert.Equal(new DateOnly(2026, 6, 10), result.EarliestExpiryDate);
+        }
+
+        [Fact]
+        public void EarliestExpiryDate_IsNullWhenNoItemHasDate()
+        {
+            var inventory = BuildInventory(
+                new InventoryItem { IsActive = true, ExpiryDate = null });
+
+            var result = InventoryResponse.ToProjection.Compile().Invoke(inventory);
+
+            Assert.Null(result.EarliestExpiryDate);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails to compile**
+
+Run: `dotnet test Application/Frigorino.Test --filter "FullyQualifiedName~InventoryResponseProjectionTests"`
+Expected: FAIL — `InventoryResponse` has no `EarliestExpiryDate` member (compile error).
+
+- [ ] **Step 3: Add the field to `InventoryResponse`**
+
+In `InventoryResponse.cs`, add the record parameter, the `From` argument, and the projection line.
+
+Record header — add `DateOnly? EarliestExpiryDate` after `ExpiringItems`:
+
+```csharp
+    public sealed record InventoryResponse(
+        int Id,
+        string Name,
+        string? Description,
+        int HouseholdId,
+        DateTime CreatedAt,
+        DateTime UpdatedAt,
+        InventoryCreatorResponse CreatedByUser,
+        int TotalItems,
+        int ExpiringItems,
+        DateOnly? EarliestExpiryDate)
+    {
+```
+
+`From` factory — add the matching argument. Change its signature and body:
+
+```csharp
+        public static InventoryResponse From(Inventory inventory, User creator, int totalItems, int expiringItems, DateOnly? earliestExpiryDate)
+        {
+            return new InventoryResponse(
+                inventory.Id,
+                inventory.Name,
+                inventory.Description,
+                inventory.HouseholdId,
+                inventory.CreatedAt,
+                inventory.UpdatedAt,
+                new InventoryCreatorResponse(creator.ExternalId, creator.Name, creator.Email),
+                totalItems,
+                expiringItems,
+                earliestExpiryDate);
+        }
+```
+
+`ToProjection` — add the earliest-expiry subquery as the final constructor argument (after the `ExpiringItems` count line):
+
+```csharp
+        public static readonly Expression<Func<Inventory, InventoryResponse>> ToProjection = i => new InventoryResponse(
+            i.Id,
+            i.Name,
+            i.Description,
+            i.HouseholdId,
+            i.CreatedAt,
+            i.UpdatedAt,
+            new InventoryCreatorResponse(i.CreatedByUser.ExternalId, i.CreatedByUser.Name, i.CreatedByUser.Email),
+            i.InventoryItems.Count(x => x.IsActive),
+            i.InventoryItems.Count(x => x.IsActive && x.ExpiryDate.HasValue && x.ExpiryDate.Value <= DateOnly.FromDateTime(DateTime.UtcNow).AddDays(ExpiringWithinDays)),
+            i.InventoryItems
+                .Where(x => x.IsActive && x.ExpiryDate != null)
+                .OrderBy(x => x.ExpiryDate)
+                .Select(x => x.ExpiryDate)
+                .FirstOrDefault());
+```
+
+> Note: if any other call site uses `InventoryResponse.From` (grep before assuming none), update it to pass the new argument. The read slices use `ToProjection`, not `From`.
+
+- [ ] **Step 4: Check for other `From` callers**
+
+Run: `grep -rn "InventoryResponse.From" Application/`
+If any non-test caller exists, add a 5th argument (the earliest expiry, or `null` if not readily available) so it compiles.
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `dotnet test Application/Frigorino.Test --filter "FullyQualifiedName~InventoryResponseProjectionTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Application/Frigorino.Features/Inventories/InventoryResponse.cs Application/Frigorino.Test/Features/InventoryResponseProjectionTests.cs
+git commit -m "feat(inventories): expose earliest expiry date on inventory response"
+```
+
+---
+
+### Task 6: Regenerate the API client
+
+**Files:**
+- Modify (generated): `Application/Frigorino.Web/ClientApp/src/lib/api/*` and `src/lib/openapi.json`
+
+- [ ] **Step 1: Regenerate**
+
+Run (from `Application/Frigorino.Web/ClientApp/`): `npm run api`
+Expected: rebuilds the backend, emits `openapi.json`, regenerates the TS client. `InventoryResponse` in `src/lib/api/types.gen.ts` now includes `earliestExpiryDate: null | string;`.
+
+- [ ] **Step 2: Verify the new field is present**
+
+Run: `grep -n "earliestExpiryDate" src/lib/api/types.gen.ts`
+Expected: one match in the `InventoryResponse` type.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npm run tsc`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/lib/api Application/Frigorino.Web/ClientApp/src/lib/openapi.json
+git commit -m "chore(api): regenerate client with earliestExpiryDate"
+```
+
+---
+
+### Task 7: Colored earliest-expiry chip on the inventory list
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/inventories/components/InventorySummaryCard.tsx`
+
+Reuse `getExpiryInfo` (relative text, e.g. "expires in 2 days") and `getExpiryColor` (red/orange/yellow/green) from `utils/dateUtils.ts`. Show the chip only when `earliestExpiryDate` is present. For dates >30 days out `getExpiryInfo` returns an empty `humanReadable`, so fall back to the formatted date.
+
+- [ ] **Step 1: Add imports**
+
+At the top of `InventorySummaryCard.tsx`, after the existing `@mui/material` import, add the dateUtils import (and `useTranslation`):
+
+```tsx
+import { useTranslation } from "react-i18next";
+import {
+    formatLocalDate,
+    getExpiryColor,
+    getExpiryInfo,
+} from "../../../utils/dateUtils";
+```
+
+- [ ] **Step 2: Build the chip inside the component**
+
+Inside `InventorySummaryCard`, before the `return`, add (the `translateKey` wrapper mirrors `InventoryItemContent` because `getExpiryInfo` expects a `(key: string) => string`):
+
+```tsx
+    const { t } = useTranslation();
+    // getExpiryInfo expects a plain (key) => string; the i18n t has stricter overloads.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const translateKey = (key: string): string => t(key as any);
+
+    const expiry = inventory.earliestExpiryDate;
+    const expiryLabel = expiry
+        ? getExpiryInfo(expiry, translateKey).humanReadable ||
+          formatLocalDate(expiry)
+        : null;
+```
+
+- [ ] **Step 3: Render the chip in the `secondaryAction`**
+
+In the `secondaryAction` `<Box>`, add the expiry chip **before** the existing date `<Chip>` (so order is: expiry chip, date chip, menu button):
+
+```tsx
+                                {expiry && expiryLabel && (
+                                    <Chip
+                                        label={expiryLabel}
+                                        size="small"
+                                        variant="outlined"
+                                        data-testid={`inventory-earliest-expiry-${inventory.name}`}
+                                        sx={{
+                                            color: getExpiryColor(expiry),
+                                            borderColor: getExpiryColor(expiry),
+                                        }}
+                                    />
+                                )}
+```
+
+- [ ] **Step 4: Type-check & lint**
+
+Run: `npm run tsc && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/features/inventories/components/InventorySummaryCard.tsx
+git commit -m "feat(inventories): colored earliest-expiry chip on inventory cards"
+```
+
+---
+
+## Phase D — Standardized page header & action placement
+
+### Task 8: Extend `PageHeadActionBar` (maxWidth + menu test ids)
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx`
+
+Two additions, both backward-compatible: (1) optional `maxWidth` so wider (`md`) form pages match their content; (2) apply `action.testId` to menu items + an optional `menuButtonTestId` on the overflow button, so pages migrating off custom menus keep their integration-test ids.
+
+- [ ] **Step 1: Extend the props interface**
+
+Add `Breakpoint` to the `@mui/material` import and extend `HeadNavigationProps`:
+
+```tsx
+import {
+    Box,
+    type Breakpoint,
+    Container,
+    IconButton,
+    ListItemIcon,
+    ListItemText,
+    Menu,
+    MenuItem,
+    Typography,
+} from "@mui/material";
+```
+
+```tsx
+export interface HeadNavigationProps {
+    title: string;
+    subtitle?: string;
+    menuActions: HeadNavigationAction[];
+    directActions: HeadNavigationAction[];
+    maxWidth?: Breakpoint;
+    menuButtonTestId?: string;
+}
+```
+
+- [ ] **Step 2: Use the new props**
+
+Destructure them with a default:
+
+```tsx
+    ({
+        title,
+        subtitle,
+        menuActions,
+        directActions,
+        maxWidth = "sm",
+        menuButtonTestId,
+    }: HeadNavigationProps) => {
+```
+
+Use `maxWidth` on the `<Container maxWidth="sm" ...>` → `<Container maxWidth={maxWidth} ...>`.
+
+Add the test id to the overflow `<IconButton onClick={handleMenuOpen} ...>` (the one rendering `<MoreVert />`):
+
+```tsx
+                                <IconButton
+                                    onClick={handleMenuOpen}
+                                    data-testid={menuButtonTestId}
+                                    sx={{
+                                        bgcolor: "grey.100",
+                                        color: "grey.700",
+                                        "&:hover": { bgcolor: "grey.200" },
+                                    }}
+                                >
+                                    <MoreVert />
+                                </IconButton>
+```
+
+Add the test id to each menu `<MenuItem>`:
+
+```tsx
+                        {menuActions.map((action, index) => (
+                            <MenuItem
+                                key={index}
+                                onClick={() => handleMenuAction(action)}
+                                data-testid={action.testId}
+                            >
+                                {action.icon && (
+                                    <ListItemIcon>{action.icon}</ListItemIcon>
+                                )}
+                                <ListItemText
+                                    primary={action.text}
+                                    secondary={action.secondaryText}
+                                />
+                            </MenuItem>
+                        ))}
+```
+
+- [ ] **Step 3: Type-check & lint**
+
+Run: `npm run tsc && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
+git commit -m "feat(header): add maxWidth + menu test ids to PageHeadActionBar"
+```
+
+---
+
+### Task 9: Slim overview action menus to delete-only
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/lists/components/ListActionsMenu.tsx`
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/inventories/components/InventoryActionsMenu.tsx`
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx`
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx`
+
+Both menus currently show a permanently `disabled` "Edit" item (dead UI). Remove it and its now-unused `onEdit` prop. Done together with the pages that pass `onEdit`, so the build stays green.
+
+- [ ] **Step 1: `ListActionsMenu.tsx` — drop Edit**
+
+Replace the file body so the import drops `Edit`, the props drop `onEdit`, and the disabled Edit `MenuItem` is gone:
+
+```tsx
+import { Delete } from "@mui/icons-material";
+import { Menu, MenuItem } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+interface ListActionsMenuProps {
+    anchorEl: HTMLElement | null;
+    onClose: () => void;
+    onDelete: () => void;
+    isDeleting?: boolean;
+}
+
+export const ListActionsMenu = ({
+    anchorEl,
+    onClose,
+    onDelete,
+    isDeleting = false,
+}: ListActionsMenuProps) => {
+    const { t } = useTranslation();
+
+    return (
+        <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={onClose}
+            elevation={4}
+            slotProps={{ paper: { sx: { minWidth: 160 } } }}
+        >
+            <MenuItem
+                onClick={onDelete}
+                disabled={isDeleting}
+                data-testid="delete-list-button"
+                sx={{ color: "error.main" }}
+            >
+                <Delete fontSize="small" sx={{ mr: 1 }} />
+                {t("common.delete")}
+            </MenuItem>
+        </Menu>
+    );
+};
+```
+
+- [ ] **Step 2: `InventoryActionsMenu.tsx` — drop Edit**
+
+Same change for inventories:
+
+```tsx
+import { Delete } from "@mui/icons-material";
+import { Menu, MenuItem } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+interface InventoryActionsMenuProps {
+    anchorEl: HTMLElement | null;
+    onClose: () => void;
+    onDelete: () => void;
+    isDeleting?: boolean;
+}
+
+export const InventoryActionsMenu = ({
+    anchorEl,
+    onClose,
+    onDelete,
+    isDeleting = false,
+}: InventoryActionsMenuProps) => {
+    const { t } = useTranslation();
+
+    return (
+        <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={onClose}
+            elevation={4}
+            slotProps={{ paper: { sx: { minWidth: 160 } } }}
+        >
+            <MenuItem
+                onClick={onDelete}
+                disabled={isDeleting}
+                data-testid="delete-inventory-button"
+                sx={{ color: "error.main" }}
+            >
+                <Delete fontSize="small" sx={{ mr: 1 }} />
+                {t("common.delete")}
+            </MenuItem>
+        </Menu>
+    );
+};
+```
+
+- [ ] **Step 3: `ListsPage.tsx` — remove the `onEdit` wiring**
+
+Delete the now-unused handler (line 71):
+
+```tsx
+    const handleEditList = () => handleMenuClose();
+```
+
+And remove the `onEdit` prop from the `<ListActionsMenu>` usage:
+
+```tsx
+            <ListActionsMenu
+                anchorEl={anchorEl}
+                onClose={handleMenuClose}
+                onDelete={handleDeleteList}
+                isDeleting={deleteListMutation.isPending}
+            />
+```
+
+- [ ] **Step 4: `InventoriesPage.tsx` — remove the `onEdit` wiring**
+
+Delete the handler (line 72):
+
+```tsx
+    const handleEditInventory = () => handleMenuClose();
+```
+
+And the `onEdit` prop from `<InventoryActionsMenu>`:
+
+```tsx
+            <InventoryActionsMenu
+                anchorEl={anchorEl}
+                onClose={handleMenuClose}
+                onDelete={handleDeleteInventory}
+                isDeleting={deleteInventoryMutation.isPending}
+            />
+```
+
+- [ ] **Step 5: Type-check & lint**
+
+Run: `npm run tsc && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/features/lists/components/ListActionsMenu.tsx Application/Frigorino.Web/ClientApp/src/features/inventories/components/InventoryActionsMenu.tsx Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx
+git commit -m "refactor(menus): remove dead disabled Edit from overview menus"
+```
+
+---
+
+### Task 10: Migrate Lists & Inventories overview pages to the shared header
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx`
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx`
+
+Replace each page's hand-rolled header `<Box>` (back + title + labeled Create button) with `<PageHeadActionBar>`; Create becomes the primary inline (`Add`) action. The back button is built in (uses `router.history.back()`).
+
+- [ ] **Step 1: `ListsPage.tsx` — imports**
+
+Change the imports: drop `ArrowBack` and `IconButton` (no longer used in the header); add `PageHeadActionBar`. New top imports:
+
+```tsx
+import { Add } from "@mui/icons-material";
+import {
+    Alert,
+    Box,
+    Button,
+    Card,
+    CardContent,
+    CircularProgress,
+    Container,
+    Stack,
+    Typography,
+} from "@mui/material";
+```
+
+Add after the existing `pageContainerSx` import:
+
+```tsx
+import { PageHeadActionBar } from "../../../components/shared/PageHeadActionBar";
+```
+
+- [ ] **Step 2: `ListsPage.tsx` — replace the header**
+
+Replace the main return's outer wrapper + header `<Box>` (lines 89–126, from `<Container ...>` through the closing `</Box>` of the header) so the page renders the shared header above the content Container:
+
+```tsx
+    return (
+        <>
+            <PageHeadActionBar
+                title={t("lists.shoppingLists")}
+                directActions={[{ icon: <Add />, onClick: handleCreateList }]}
+                menuActions={[]}
+            />
+            <Container maxWidth="sm" sx={pageContainerSx}>
+```
+
+Then, at the very end of the component's main return, close the fragment — change the final `</Container>` (the one wrapping the content, after `<ListActionsMenu .../>`) to:
+
+```tsx
+            </Container>
+        </>
+    );
+```
+
+(The `!householdId` early-return Container is unchanged. `handleBack` is still used there, so keep it.)
+
+- [ ] **Step 3: `InventoriesPage.tsx` — imports**
+
+Same import change: drop `ArrowBack`/`IconButton`, add `PageHeadActionBar`:
+
+```tsx
+import { Add } from "@mui/icons-material";
+import {
+    Alert,
+    Box,
+    Button,
+    Card,
+    CardContent,
+    CircularProgress,
+    Container,
+    Stack,
+    Typography,
+} from "@mui/material";
+```
+
+```tsx
+import { PageHeadActionBar } from "../../../components/shared/PageHeadActionBar";
+```
+
+- [ ] **Step 4: `InventoriesPage.tsx` — replace the header**
+
+Replace the main return wrapper + header `<Box>` (lines 90–127):
+
+```tsx
+    return (
+        <>
+            <PageHeadActionBar
+                title={t("inventory.inventories")}
+                directActions={[
+                    { icon: <Add />, onClick: handleCreateInventory },
+                ]}
+                menuActions={[]}
+            />
+            <Container maxWidth="sm" sx={pageContainerSx}>
+```
+
+And close the fragment at the end (after `<InventoryActionsMenu .../>`):
+
+```tsx
+            </Container>
+        </>
+    );
+```
+
+- [ ] **Step 5: Type-check & lint**
+
+Run: `npm run tsc && npm run lint`
+Expected: PASS (no unused `ArrowBack`/`IconButton`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListsPage.tsx Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoriesPage.tsx
+git commit -m "feat(header): standardize Lists/Inventories overview headers"
+```
+
+---
+
+### Task 11: Migrate List & Inventory edit pages to the shared header
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListEditPage.tsx`
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryEditPage.tsx`
+
+Each edit page has a custom header (back + title + a `MoreVert` menu whose only item is Delete → opens a confirm dialog). Replace with `<PageHeadActionBar maxWidth="md">` where Delete is a single `menuAction`. The pages keep `maxWidth="md"` content, so pass `maxWidth="md"` to the header.
+
+- [ ] **Step 1: `ListEditPage.tsx` — imports**
+
+Replace the icon + MUI imports (drop `ArrowBack`, `IconButton`, `ListItemIcon`, `ListItemText`, `Menu`, `MenuItem`, `MoreVert`, and `Typography` — Typography was only in the header; keep `Delete` for the menu action icon) and the router import (drop `useRouter` — the header owns back). Add the header import:
+
+```tsx
+import { Delete } from "@mui/icons-material";
+import { Alert, Box, Container, Skeleton } from "@mui/material";
+import { useParams } from "@tanstack/react-router";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+    PageHeadActionBar,
+    type HeadNavigationAction,
+} from "../../../components/shared/PageHeadActionBar";
+import { pageContainerSx } from "../../../theme";
+```
+
+(Keep the existing `useCurrentHouseholdWithDetails`, `DeleteListConfirmDialog`, `EditListForm`, `useList` imports.)
+
+- [ ] **Step 2: `ListEditPage.tsx` — remove menu state/handlers, add menu action**
+
+Delete the menu anchor state and handlers (lines 30, 51–53): remove `const [menuAnchor, setMenuAnchor] = ...`, `handleMenuClick`, `handleMenuClose`. Also remove `const router = useRouter();` (line 24) and `handleBack` (line 50) — both now unused (the header owns back). Keep `deleteDialogOpen` state. Change `handleDeleteClick` to just open the dialog:
+
+```tsx
+    const handleDeleteClick = () => setDeleteDialogOpen(true);
+```
+
+- [ ] **Step 3: `ListEditPage.tsx` — replace header + menu markup**
+
+Replace the final return's header `<Box>` (lines 110–144) and the `<Menu>` block (lines 148–173) with the shared header. The return becomes:
+
+```tsx
+    const menuActions: HeadNavigationAction[] = [
+        {
+            text: t("lists.deleteList"),
+            icon: <Delete fontSize="small" />,
+            onClick: handleDeleteClick,
+        },
+    ];
+
+    return (
+        <>
+            <PageHeadActionBar
+                title={t("lists.editList")}
+                maxWidth="md"
+                directActions={[]}
+                menuActions={menuActions}
+            />
+            <Container maxWidth="md" sx={pageContainerSx}>
+                <EditListForm householdId={householdId} list={list} />
+
+                {list.id && (
+                    <DeleteListConfirmDialog
+                        open={deleteDialogOpen}
+                        onClose={() => setDeleteDialogOpen(false)}
+                        householdId={householdId}
+                        listId={list.id}
+                        listName={listName}
+                    />
+                )}
+            </Container>
+        </>
+    );
+```
+
+(The loading/error/no-household/no-list early returns keep their own `<Container maxWidth="md">` — unchanged.)
+
+- [ ] **Step 4: `InventoryEditPage.tsx` — imports**
+
+(Same rationale as ListEditPage: drop `Typography` and `useRouter`.)
+
+```tsx
+import { Delete } from "@mui/icons-material";
+import { Alert, Box, Container, Skeleton } from "@mui/material";
+import { useParams } from "@tanstack/react-router";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+    PageHeadActionBar,
+    type HeadNavigationAction,
+} from "../../../components/shared/PageHeadActionBar";
+import { pageContainerSx } from "../../../theme";
+```
+
+(Keep `useCurrentHouseholdWithDetails`, `DeleteInventoryConfirmDialog`, `EditInventoryForm`, `InventorySettingsCard`, `useInventory`.)
+
+- [ ] **Step 5: `InventoryEditPage.tsx` — remove menu state/handlers**
+
+Remove `menuAnchor` state, `handleMenuClick`, `handleMenuClose`, `handleBack`, and `const router = useRouter();` (all now unused); simplify delete:
+
+```tsx
+    const handleDeleteClick = () => setDeleteDialogOpen(true);
+```
+
+- [ ] **Step 6: `InventoryEditPage.tsx` — replace header + menu markup**
+
+Replace the header `<Box>` (lines 115–147) and the `<Menu>` block (lines 161–186):
+
+```tsx
+    const menuActions: HeadNavigationAction[] = [
+        {
+            text: t("inventory.deleteInventory"),
+            icon: <Delete fontSize="small" />,
+            onClick: handleDeleteClick,
+        },
+    ];
+
+    return (
+        <>
+            <PageHeadActionBar
+                title={t("inventory.editInventory")}
+                maxWidth="md"
+                directActions={[]}
+                menuActions={menuActions}
+            />
+            <Container maxWidth="md" sx={pageContainerSx}>
+                <EditInventoryForm
+                    householdId={householdId}
+                    inventory={inventory}
+                />
+
+                {inventory.id && (
+                    <InventorySettingsCard
+                        householdId={householdId}
+                        inventoryId={inventory.id}
+                    />
+                )}
+
+                {inventory.id && (
+                    <DeleteInventoryConfirmDialog
+                        open={deleteDialogOpen}
+                        onClose={() => setDeleteDialogOpen(false)}
+                        householdId={householdId}
+                        inventoryId={inventory.id}
+                        inventoryName={inventoryName}
+                    />
+                )}
+            </Container>
+        </>
+    );
+```
+
+- [ ] **Step 7: Type-check & lint**
+
+Run: `npm run tsc && npm run lint`
+Expected: PASS. (`Box`/`Skeleton` are still used by the loading-skeleton early returns; `Typography` is NOT used after the header is removed, which is why it was dropped from the imports.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListEditPage.tsx Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryEditPage.tsx
+git commit -m "feat(header): standardize List/Inventory edit headers"
+```
+
+---
+
+### Task 12: Migrate Manage-household page to the shared header (preserve test ids)
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/households/pages/ManageHouseholdPage.tsx`
+
+Integration tests click `household-manage-menu-toggle` and `household-manage-menu-delete`, so pass `menuButtonTestId="household-manage-menu-toggle"` and the delete action `testId="household-manage-menu-delete"`. The delete menu item only shows for owners.
+
+- [ ] **Step 1: Imports**
+
+Replace the icon + MUI imports (drop `ArrowBack`, `IconButton`, `ListItemIcon`, `ListItemText`, `Menu`, `MenuItem`, `MoreVert`, and `Typography` — Typography was only in the header; keep `Delete`) and drop the `useNavigate` router import entirely (the back button moves into the header). Add the header import:
+
+```tsx
+import { Delete } from "@mui/icons-material";
+import { Alert, Box, Container, Skeleton } from "@mui/material";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+    PageHeadActionBar,
+    type HeadNavigationAction,
+} from "../../../components/shared/PageHeadActionBar";
+import { pageContainerSx } from "../../../theme";
+```
+
+(Keep the remaining domain imports: `useCurrentHouseholdWithDetails`, `DeleteHouseholdDialog`, `HouseholdSettingsCard`, `HouseholdSummaryCard`, `HouseholdRoleValue`, `roleRank`, `MembersPanel`, `useHouseholdMembers`.)
+
+- [ ] **Step 2: Remove menu anchor state + unused navigate**
+
+Delete `const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);` (line 30) and `const navigate = useNavigate();` (line 27) — `navigate` was only used by the old back button. Keep `deleteDialogOpen`.
+
+- [ ] **Step 3: Replace header + menu markup**
+
+Replace the header wrapper `<Box sx={{ mb... }}>` containing the inner header `<Box>` + `HouseholdSummaryCard` (lines 91–134) and the `<Menu>` block (lines 146–177). Build the menu action conditionally for owners and render via the shared header:
+
+```tsx
+    const menuActions: HeadNavigationAction[] = isOwner
+        ? [
+              {
+                  text: t("household.deleteHousehold"),
+                  icon: <Delete fontSize="small" />,
+                  onClick: () => setDeleteDialogOpen(true),
+                  testId: "household-manage-menu-delete",
+              },
+          ]
+        : [];
+
+    return (
+        <>
+            <PageHeadActionBar
+                title={t("household.householdManagement")}
+                maxWidth="md"
+                directActions={[]}
+                menuActions={menuActions}
+                menuButtonTestId="household-manage-menu-toggle"
+            />
+            <Container maxWidth="md" sx={pageContainerSx}>
+                <Box sx={{ mb: { xs: 2, sm: 3 } }}>
+                    <HouseholdSummaryCard
+                        householdName={householdName}
+                        memberCount={members?.length ?? 0}
+                        userRole={userRole}
+                    />
+                </Box>
+
+                <MembersPanel
+                    householdId={currentHousehold.householdId}
+                    currentUserRole={userRole}
+                />
+
+                <HouseholdSettingsCard
+                    householdId={currentHousehold.householdId}
+                    canManage={canManageSettings}
+                />
+
+                <DeleteHouseholdDialog
+                    open={deleteDialogOpen}
+                    onClose={() => setDeleteDialogOpen(false)}
+                    householdId={currentHousehold.householdId}
+                    householdName={householdName}
+                />
+            </Container>
+        </>
+    );
+```
+
+> Note: when `isOwner` is false, `menuActions` is empty and `PageHeadActionBar` renders no overflow button — matching today's behavior (the menu toggle only showed for owners). The IT asserts the toggle is hidden for non-owners (`HouseholdSteps.cs:91`); that still holds.
+
+- [ ] **Step 4: Type-check & lint**
+
+Run: `npm run tsc && npm run lint`
+Expected: PASS. (`Box`/`Skeleton`/`Typography`/`Alert` still used in early returns — keep.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/features/households/pages/ManageHouseholdPage.tsx
+git commit -m "feat(header): standardize manage-household header (keep test ids)"
+```
+
+---
+
+### Task 13: Add a back button to User Settings via the shared header
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/settings/pages/UserSettingsPage.tsx`
+
+The settings page is the only one with no back navigation (just an `h5` title). Add the shared header above the content; drop the bare title.
+
+- [ ] **Step 1: Add the import**
+
+After the `pageContainerSx` import, add:
+
+```tsx
+import { PageHeadActionBar } from "../../../components/shared/PageHeadActionBar";
+```
+
+- [ ] **Step 2: Replace the title with the header**
+
+Change the start of the returned JSX. Replace:
+
+```tsx
+    return (
+        <Container maxWidth="sm" sx={pageContainerSx}>
+            <Typography variant="h5" sx={{ mb: { xs: 2, sm: 3 } }}>
+                {t("settings.userSettings")}
+            </Typography>
+```
+
+with:
+
+```tsx
+    return (
+        <>
+            <PageHeadActionBar
+                title={t("settings.userSettings")}
+                directActions={[]}
+                menuActions={[]}
+            />
+            <Container maxWidth="sm" sx={pageContainerSx}>
+```
+
+Then close the fragment at the very end — change the final `</Container>` to:
+
+```tsx
+            </Container>
+        </>
+    );
+```
+
+- [ ] **Step 3: Remove the now-unused `Typography` import**
+
+`Typography` is still used inside the notifications card (`<Typography variant="h6">`), so **keep** the import. (Verify with `npm run lint`.)
+
+- [ ] **Step 4: Type-check & lint**
+
+Run: `npm run tsc && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/features/settings/pages/UserSettingsPage.tsx
+git commit -m "feat(settings): add back navigation via shared header"
+```
+
+---
+
+## Phase E — Verification
+
+### Task 14: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Frontend gate**
+
+Run (from `Application/Frigorino.Web/ClientApp/`): `npm run lint && npm run tsc && npm run prettier`
+Expected: all PASS. (If `prettier` rewrites files, commit the formatting: `git commit -am "style: prettier"`.)
+
+- [ ] **Step 2: Build the SPA into `ClientApp/build`**
+
+Integration tests serve `ClientApp/build`, so rebuild it (also catches any vite/tsc build break the dev type-check missed).
+Run: `npm run build`
+Expected: PASS, outputs to `build/`.
+
+- [ ] **Step 3: Full solution tests**
+
+Run (from repo root): `dotnet test Application/Frigorino.sln`
+Expected: PASS (includes the new `InventoryResponseProjectionTests` and the household/settings integration tests that exercise the migrated headers). Capture `${PIPESTATUS[0]}` / read the pass-fail summary — do not trust a piped tail.
+
+- [ ] **Step 4: Manual mobile-first sweep (dev-up + browser)**
+
+Bring up the stack (`/dev-up`) and visually confirm on a phone-width viewport:
+- Promote bar reads as a calm tinted banner with a green button (add a perishable, check it off to trigger it).
+- Dashboard shopping-list rows show "N open" chip + "M items total" subtitle (no `6/1`).
+- Inventories page shows a colored earliest-expiry chip per inventory; none when an inventory has no dated items.
+- Checked list items grey out with **no** strikethrough on text or quantity chip.
+- Every page (lists, inventories, list/inventory edit, manage household, **user settings**) has a back button in a consistent header; overview "create" is the green inline action; edit/manage delete lives in the overflow `⋮`.
+
+- [ ] **Step 5: (Optional, final gate) Docker build**
+
+If the Dockerfile or project set changed (it didn't here), run `docker build -f Application/Dockerfile -t frigorino .`. Not required for this UI-only change, but run it before promoting if in doubt.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** §1 palette → Task 1; §2 promote bar → Task 2; §3 list count → Task 4; §4 expiry chip → Tasks 5–7; §5 strikethrough → Task 3; §6 header/menus → Tasks 8–13. All covered.
+- **Deferred (per spec, not in plan):** icon-set refinement, bottom-nav/mobile-nav rework, dashboard layout changes. Dashboard inventory expiry is surfaced as text via Task 4's `status` render; the *colored chip* requirement is delivered on the Inventories page (the canonical "inventory lists"), matching the spec's primary target.
+- **Type consistency:** `EarliestExpiryDate` (C# `DateOnly?`) ↔ generated `earliestExpiryDate: null | string` ↔ consumed by `getExpiryInfo`/`getExpiryColor`/`formatLocalDate` (all take `string`). `HeadNavigationAction.testId` is reused for menu items. `maxWidth` typed as MUI `Breakpoint`.
+- **Build-green ordering:** Task 9 changes the menu components and their callers together; Task 6 regenerates the client before Task 7 consumes the new field.
+```

--- a/docs/superpowers/specs/2026-06-02-section-color-identity.md
+++ b/docs/superpowers/specs/2026-06-02-section-color-identity.md
@@ -1,0 +1,76 @@
+# Section Color Identity — Design Note
+
+**Date:** 2026-06-02
+**Status:** Decided (palette + dashboard application). App-wide rollout deferred.
+
+## Problem
+
+The dashboard painted a hardcoded per-feature color (`#2196F3` blue / `#FF9800`
+orange / `#4CAF50` green) onto four surfaces at once — the section icon, the `+`
+button, the `›` chevron, and the per-item bullet dots. Three features × four
+surfaces produced color overload, and because color was pure decoration
+("which feature"), the genuinely meaningful color (the red/amber expiry chip)
+did not stand out.
+
+An earlier experiment swapping the whole app's `primary` per route was rejected
+as "too colorful."
+
+## Decision
+
+**Direction "quiet identity" (C):** color identifies a section only through the
+small **icon glyph**. All other chrome (`+`, chevron) is neutral grey, the
+decorative bullet dots are removed, and red/amber stay reserved for expiry
+status — so the only loud color on a card is a real warning.
+
+**Palette (V2):** one coordinated four-color family.
+
+| Section   | Color     | Notes |
+|-----------|-----------|-------|
+| Household | `#5FA86F` | green — keeps the brand identity shown in the picker |
+| Lists     | `#5A92CB` | blue |
+| Inventory | `#4BA1A1` | teal |
+| Recipes   | `#D18A77` | warm coral |
+
+### Rules baked into the choice
+
+- **Semantic separation.** Section colors never reuse the red/amber/green that
+  expiry chips and destructive actions depend on for meaning.
+- **Inventory stays cool.** Inventory must not be amber/orange because its own
+  cards carry amber/red expiry chips; a warm inventory hue would compete with
+  the warning. Hence teal.
+- **Recipes coral is safe** because Recipes has no expiry chips.
+
+## Section icons
+
+Each section has a fixed glyph, centralized in `ClientApp/src/common/sections.tsx`
+as `sectionIcons` (keyed by `SectionKey`, paired with `sectionColors`):
+
+| Section   | Icon (MUI)            |
+|-----------|-----------------------|
+| Household | `HomeOutlined`        |
+| Lists     | `ChecklistOutlined`   |
+| Inventory | `KitchenOutlined` (fridge) |
+| Recipes   | `RestaurantOutlined`  |
+
+This corrected the original dashboard mix-up where Lists used the fridge icon
+and Inventory used a timer.
+
+## Implementation
+
+- Colors centralized in `ClientApp/src/theme.ts` as `sectionColors`
+  (`household`/`lists`/`inventory`/`recipes`) + a `SectionKey` type; icons in
+  `common/sections.tsx`. Any surface consumes the tokens rather than hardcoding.
+- **Dashboard** (`components/dashboard/WelcomePage.tsx`): icon glyph uses the
+  token over a neutral `action.hover` background; `+` and chevron use
+  `text.secondary`; bullet dots removed; expiry chips unchanged.
+- **Feature headers** (`components/shared/PageHeadActionBar.tsx`): an optional
+  `section?: SectionKey` prop renders the section's icon (section-colored glyph
+  on a neutral surface) before the title — same wayfinding cue, continued into
+  the feature. Wired into Lists (list/view/edit), Inventory (list/view/edit),
+  and Household management. Settings is intentionally left without (not a
+  section).
+
+## Deferred (not in this pass)
+
+- Household switcher glyph and a future Recipes section — both purely additive
+  via the existing tokens, no rework needed.

--- a/docs/superpowers/specs/2026-06-02-ux-alignment-design.md
+++ b/docs/superpowers/specs/2026-06-02-ux-alignment-design.md
@@ -1,0 +1,126 @@
+# UX Alignment — Design Spec
+
+**Date:** 2026-06-02
+**Status:** Approved (design), pending spec review
+**Source:** Six usability items raised by the user, consolidated into one design pass.
+
+## Goal
+
+Tighten the visual consistency and clarity of the Frigorino SPA. Establish a real theme (today it runs on raw MUI dark defaults), fix three concrete chip/label issues, and standardize page headers + action placement. This is the first batch of a broader look-and-feel alignment; a deeper pass (icon set, navigation paradigm) is explicitly deferred.
+
+## Cross-cutting principles
+
+- **Visual direction A — "subtle & semantic"** (chosen): calm neutral surfaces; brand color used sparingly; loud solid fills replaced by soft tinted banners; color reserved for *meaning* (e.g. expiry status). The clashing default pink secondary is dropped.
+- **Mobile-first:** comfortable touch targets (≥ ~40px / MUI default IconButton), no hover-only affordances (every action reachable by tap), chips/labels legible at small sizes. A deeper mobile-nav rework (bottom tab bar, etc.) is **out of scope** — flagged for the future design session.
+- **i18n:** every new/changed user-facing string goes through `t()` with keys added to both `en` and `de` translation files. Tests never assert on translated text.
+
+---
+
+## 1. Theme palette (`ClientApp/src/theme.ts`)
+
+Today `createTheme({ palette: { mode: "dark" } })` uses MUI defaults (`primary` ≈ light blue `#90caf9`, `secondary` ≈ pink `#f48fb1`). Introduce an explicit palette so chrome (buttons, banners, primary actions) is intentional and consistent app-wide.
+
+- **primary:** fresh green — proposed `#43A047` (main). Thematically apt for a food/fridge app; used sparingly per direction A.
+- **secondary:** warm amber — proposed `#FFB300`. Replaces the pink.
+- **semantic:** keep MUI `error` / `warning` / `success`; expiry coloring continues to use the existing `getExpiryColor()` thresholds (red < 2d, orange < 1w, yellow `#FFD700` < 2w, green otherwise).
+- **Category accents stay as-is:** dashboard categories (lists = `#2196F3`, inventory = `#FF9800`, recipes = `#4CAF50`) remain as per-category accent colors; the palette governs chrome, not these.
+
+Exact hex values are a starting proposal and may be tuned during implementation. Because this changes global chrome, verify a visual sweep of the main pages after applying.
+
+> Note: green-as-primary (actions) coexists with green-as-success (expiry OK) and the green recipes accent. Acceptable because direction A uses brand color sparingly and the contexts rarely co-occur; revisit if it reads as "too much green".
+
+## 2. Promote bar restyle (`features/lists/promote/PromoteBar.tsx`)
+
+Replace the loud fill + pink button with a soft tinted banner:
+
+- Container: soft tint of primary (e.g. low-opacity primary background) with a left accent border in primary; normal-weight text (not `contrastText` on a solid fill).
+- Button: `variant="contained" color="primary"` (drop `color="secondary"`).
+- Keep the icon, the `promote.barReady` text, the `promote-bar-review` testid, and the conditional render (`entries.length > 0`).
+
+## 3. Shopping-list count — "open only" (#2)
+
+**Problem:** the dashboard list rows show `${checkedCount}/${uncheckedCount}` (e.g. `6/1`) as **both** the chip label and the subtitle — confusing and duplicated. The computed date `status` is never rendered.
+
+**Fix (`components/dashboard/WelcomePage.tsx`):**
+- Chip label → **open count only**: `"{open} offen"` where open = number of unchecked (not-yet-done) items.
+- Subtitle → **total**: `"{total} Artikel gesamt"`, total = checked + unchecked. (Confirm exact field names on `ListResponse`; open = unchecked items, total = all items.)
+- Remove the duplicate `secondary={item.count}` rendering of the same string.
+- This affects only the shopping-list collection mapping; inventory rows are handled in §4.
+
+New translation keys (en/de), e.g. `lists.openCount` ("{{count}} offen" / "{{count}} open") and `lists.totalItems` ("{{count}} Artikel gesamt" / "{{count}} items total").
+
+## 4. Inventory earliest-expiry chip (#3)
+
+Show a chip on each inventory in the inventory lists with the **earliest upcoming expiry**, colored by urgency, using relative time.
+
+**Backend (`Features/Inventories/InventoryResponse.cs` + projection):**
+- Add `DateOnly? EarliestExpiryDate` (or `DateTime?` to match the item field — confirm the entity type) to the `InventoryResponse` record, the `From` factory, and the `ToProjection` expression.
+- Projection: minimum `ExpiryDate` among active items that have one, e.g. `i.InventoryItems.Where(x => x.IsActive && x.ExpiryDate.HasValue).Min(x => x.ExpiryDate)`. Must stay EF-translatable (verify the `Min` over nullable translates; adjust if needed).
+- `GetInventories` and `GetInventory` both use `ToProjection`, so both pick it up automatically.
+- Regenerate the TS client: `npm run api` from `ClientApp/`.
+
+**Frontend:**
+- Primary target: `features/inventories/components/InventorySummaryCard.tsx` — add a chip showing relative time to `earliestExpiryDate`, colored via `getExpiryColor()`. Reuse the existing relative formatter in `utils/dateUtils.ts` (`formatExpiry` → "in X Tagen/Wochen").
+- Also apply to the dashboard inventory rows (`WelcomePage.tsx`) for consistency — this requires extending the collection item shape to carry optional expiry info (date) so the generic card can render a colored chip. Keep minimal.
+- **No chip** when the inventory has no items, or no items with an expiry date.
+
+## 5. Remove strikethrough on checked items (#5)
+
+**Decision:** no strikethrough anywhere on a checked-off item — neither the quantity chip nor the item text. The existing subtle opacity gray-out (row `opacity: 0.7` in `SortableListItem`) is the only "done" signal.
+
+- `features/lists/items/components/ListItemContent.tsx`: remove the `textDecoration: item.status ? "line-through" : "none"` from the quantity `Chip` (lines ~56–61) — always `"none"` (i.e. drop the rule).
+- Verify there is no `line-through` applied to the item **text** anywhere (Explore found none on the primary text, but confirm in `SortableListItem` / `ListItemContent` and remove if present).
+- Check the inventory item row for an equivalent strikethrough and remove it too, for consistency.
+
+## 6. Unified page header + action placement (#4 + #6)
+
+**Decision:** every non-dashboard page uses the shared `components/shared/PageHeadActionBar.tsx`. Today only List view and Inventory view use it; the rest hand-roll headers, and User Settings has no back button at all.
+
+**Anatomy (every page):** back button (always) · title · 0–2 inline icon actions (frequent) · overflow `⋮` menu (rare / destructive).
+
+**Action-placement rule:**
+- Frequent actions (edit, reorder/sort) → inline icon buttons in the header (max ~2).
+- Rare / destructive (delete) → overflow `⋮` menu.
+- **No disabled menu items:** the greyed-out "Edit" entries currently in `ListActionsMenu` / `InventoryActionsMenu` are removed; edit becomes a real inline action.
+
+**Pages to migrate to `PageHeadActionBar`:**
+- List edit — drop custom header
+- Inventory edit — drop custom header
+- Lists overview (`ListsPage`) — drop custom header (keep "create" as an inline header action)
+- Inventories overview (`InventoriesPage`) — drop custom header (keep "create" as an inline header action)
+- Manage household (`ManageHouseholdPage`) — drop custom header
+- User settings (`UserSettingsPage`) — **add back button** via the shared header
+
+Real MUI icons throughout (the brainstorm mockup used emoji as stand-ins). The icon-set refinement is deferred.
+
+---
+
+## Out of scope / deferred (future design session)
+
+- Icon set / iconography refinement.
+- Deeper mobile navigation paradigm (bottom tab bar, gestures).
+- Any change to the dashboard's overall layout beyond the count/expiry fixes above.
+
+## Testing & verification
+
+- Frontend: `npm run lint`, `npm run tsc`, `npm run prettier` (write), per project convention.
+- After backend DTO change: `npm run api` to regenerate the client; ensure no TS breaks.
+- Backend: `dotnet test Application/Frigorino.sln` (covers unit + integration). Add/adjust a unit test for the `EarliestExpiryDate` projection if a suitable test seam exists.
+- Integration tests touch testids — preserve existing testids (`promote-bar-review`, `list-item-quantity-*`, MUI Select testid conventions). Rebuild `ClientApp/build` before running IT.
+- Manual mobile-first sweep of changed pages (dev-up + browser) once implemented.
+- Final gate before completion: full sln test + `docker build` per project convention.
+
+## Files touched (anticipated)
+
+- `ClientApp/src/theme.ts` — palette.
+- `ClientApp/src/features/lists/promote/PromoteBar.tsx` — restyle.
+- `ClientApp/src/components/dashboard/WelcomePage.tsx` — count (open-only), inventory expiry chip.
+- `ClientApp/src/features/inventories/components/InventorySummaryCard.tsx` — expiry chip.
+- `ClientApp/src/features/lists/items/components/ListItemContent.tsx` — remove strikethrough.
+- `ClientApp/src/features/lists/items/components/SortableListItem.tsx` (+ inventory equivalent) — confirm/remove any text strikethrough.
+- `ClientApp/src/components/shared/PageHeadActionBar.tsx` — used by migrated pages (extend if a header action slot is missing).
+- List edit / Inventory edit / `ListsPage` / `InventoriesPage` / `ManageHouseholdPage` / `UserSettingsPage` — migrate to shared header.
+- `ListActionsMenu.tsx` / `InventoryActionsMenu.tsx` — remove disabled Edit items.
+- `Features/Inventories/InventoryResponse.cs` — add `EarliestExpiryDate` to record + `From` + `ToProjection`.
+- Regenerated `ClientApp/src/lib/api/*` (via `npm run api`).
+- `ClientApp/public/locales/{en,de}/translation.json` — new keys.


### PR DESCRIPTION
## Summary

UX alignment pass from a design session covering six usability items, plus a
follow-up "section color identity" treatment. Targets `stage` for UAT.

**Theme & surfaces**
- Green/amber palette replacing the default MUI pink; calmer tinted promote bar.
- Standardized page headers (`PageHeadActionBar`) across Lists, Inventory,
  Household and Settings: consistent back navigation, destructive deletes shown
  in red, dead "disabled Edit" overview menus removed.

**Dashboard clarity**
- List rows now show "N open" + a total instead of the confusing duplicate
  count (e.g. `6/1 Artikel`).
- Colored earliest-expiry chip on inventory rows (and on the Inventories page
  cards), so the next expiration is visible at a glance.

**Inventory expiry data**
- New additive `EarliestExpiryDate` on the inventory response (EF projection +
  unit tests); generated API client regenerated.

**Item polish**
- Removed the strikethrough on checked-item quantity chips.

**Section color identity ("quiet identity")**
- Four centralized section colors (household / lists / inventory / recipes) in
  `theme.ts`, icons in `common/sections.tsx`.
- Only the section icon glyph carries a muted color; chrome stays neutral,
  bullet dots dropped, red/amber reserved for expiry meaning.
- Section icon shown in feature headers via a new `section` prop.
- Fixed swapped dashboard icons (Lists = checklist, Inventory = fridge).

Design notes: `docs/superpowers/specs/2026-06-02-ux-alignment-design.md` and
`docs/superpowers/specs/2026-06-02-section-color-identity.md`.

## Test Plan
- [x] Frontend: `tsc`, `eslint`, `prettier`, and `vite build` all clean.
- [x] Backend `EarliestExpiryDate` covered by unit tests; full suite previously
      run green (366 unit + 111 integration) on this branch.
- [ ] Visual UAT on `stage`: dashboard cards, feature headers/icons, expiry
      chip colors, header back-navigation and red destructive actions.
