### PR TITLE
feat: editable quantity in promote-to-inventory review sheet

### DIFF
--- a/Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
+++ b/Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
@@ -44,6 +44,7 @@
         "addItem": "Element hinzufügen",
         "itemName": "Elementname",
         "quantity": "Menge",
+        "unit": "Einheit",
         "invalidQuantity": "Positive Zahl eingeben oder leer lassen zum Entfernen",
         "confirmDelete": "Sind Sie sicher, dass Sie löschen möchten",
         "warningPermanentlyDelete": "⚠️ Warnung: Dies wird dauerhaft löschen:",

--- a/Application/Frigorino.Web/ClientApp/public/locales/en/translation.json
+++ b/Application/Frigorino.Web/ClientApp/public/locales/en/translation.json
@@ -44,6 +44,7 @@
         "addItem": "Add Item",
         "itemName": "Item Name",
         "quantity": "Quantity",
+        "unit": "Unit",
         "invalidQuantity": "Enter a positive number, or leave empty to clear",
         "confirmDelete": "Are you sure you want to delete",
         "warningPermanentlyDelete": "⚠️ Warning: This will permanently delete:",

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/promote/PromoteReviewSheet.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/promote/PromoteReviewSheet.tsx
@@ -1,4 +1,4 @@
-import { Close, ShoppingBag } from "@mui/icons-material";
+import { Close } from "@mui/icons-material";
 import {
     Box,
     Button,
@@ -14,7 +14,15 @@ import {
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { formatQuantity } from "../../../components/composer";
+import {
+    draftToQuantity,
+    isDraftValid,
+    quantityToDraft,
+    QUANTITY_UNIT_VALUES,
+    unitLabel,
+    type QuantityDraft,
+} from "../../../components/composer";
+import type { QuantityUnit } from "../../../lib/api";
 import { useHouseholdInventories } from "../../inventories/useHouseholdInventories";
 import { useCreateInventoryItem } from "../../inventories/items/useCreateInventoryItem";
 import { getExpiryInfo } from "../../../utils/dateUtils";
@@ -31,11 +39,13 @@ interface PromoteReviewSheetProps {
     listId: number;
 }
 
-// Per-row editable draft. Quantity is carried straight through from the source list item
-// (a structured QuantityDto), so only selection and expiry (YYYY-MM-DD) are editable here.
+// Per-row editable draft. Quantity is editable here (a QuantityDraft) so the inventory can
+// reflect what was actually bought — the store may have had fewer items, or you bought more
+// than the list requested. Expiry is YYYY-MM-DD.
 interface RowDraft {
     selected: boolean;
     expiry: string;
+    quantity: QuantityDraft;
 }
 
 export const PromoteReviewSheet = ({
@@ -68,6 +78,7 @@ export const PromoteReviewSheet = ({
             next[e.itemId] = drafts[e.itemId] ?? {
                 selected: true,
                 expiry: e.suggestedExpiry ?? "",
+                quantity: quantityToDraft(e.quantity),
             };
         }
         return next;
@@ -85,6 +96,12 @@ export const PromoteReviewSheet = ({
 
     const hasRowMissingDate = entries.some(
         (e) => seeded[e.itemId]?.selected && !seeded[e.itemId]?.expiry,
+    );
+
+    const hasRowInvalidQuantity = entries.some(
+        (e) =>
+            seeded[e.itemId]?.selected &&
+            !isDraftValid(seeded[e.itemId].quantity),
     );
 
     const handleOmit = (itemId: number) => {
@@ -113,7 +130,7 @@ export const PromoteReviewSheet = ({
                     path: { householdId, inventoryId: targetId },
                     body: {
                         text: entry.name,
-                        quantity: entry.quantity,
+                        quantity: draftToQuantity(draft.quantity),
                         expiryDate: draft.expiry || null,
                     },
                 });
@@ -229,7 +246,8 @@ export const PromoteReviewSheet = ({
                             selectedCount === 0 ||
                             !targetId ||
                             createItem.isPending ||
-                            hasRowMissingDate
+                            hasRowMissingDate ||
+                            hasRowInvalidQuantity
                         }
                         onClick={handleAdd}
                         data-testid="promote-add-button"
@@ -298,21 +316,63 @@ const PromoteRow = ({ entry, draft, onChange, onOmit }: PromoteRowProps) => {
                     <Close fontSize="small" />
                 </IconButton>
             </Stack>
-            <Stack
-                direction="row"
-                spacing={1}
-                sx={{ mt: 1, alignItems: "center" }}
-            >
+            <Stack spacing={1} sx={{ mt: 1 }}>
                 {entry.quantity && (
-                    <Chip
-                        size="small"
-                        variant="outlined"
-                        icon={<ShoppingBag fontSize="small" />}
-                        label={formatQuantity(t, entry.quantity)}
-                        data-testid={`promote-row-quantity-${entry.name}`}
-                    />
+                    <Stack
+                        direction="row"
+                        spacing={1}
+                        sx={{ alignItems: "center" }}
+                    >
+                        <TextField
+                            size="small"
+                            type="text"
+                            label={t("common.quantity")}
+                            value={draft.quantity.value}
+                            onChange={(e) =>
+                                onChange({
+                                    quantity: {
+                                        ...draft.quantity,
+                                        value: e.target.value,
+                                    },
+                                })
+                            }
+                            error={!isDraftValid(draft.quantity)}
+                            slotProps={{
+                                inputLabel: { shrink: true },
+                                htmlInput: {
+                                    inputMode: "decimal",
+                                    "data-testid": `promote-row-quantity-value-${entry.name}`,
+                                },
+                            }}
+                            sx={{ width: 90 }}
+                        />
+                        <TextField
+                            select
+                            size="small"
+                            label={t("common.unit")}
+                            value={draft.quantity.unit}
+                            onChange={(e) =>
+                                onChange({
+                                    quantity: {
+                                        ...draft.quantity,
+                                        unit: e.target.value as QuantityUnit,
+                                    },
+                                })
+                            }
+                            data-testid={`promote-row-quantity-unit-${entry.name}`}
+                            slotProps={{ inputLabel: { shrink: true } }}
+                            sx={{ flex: 1, minWidth: 120 }}
+                        >
+                            {QUANTITY_UNIT_VALUES.map((u) => (
+                                <MenuItem key={u} value={u}>
+                                    {unitLabel(t, u)}
+                                </MenuItem>
+                            ))}
+                        </TextField>
+                    </Stack>
                 )}
                 <TextField
+                    fullWidth
                     size="small"
                     type="date"
                     label={t("promote.expiry")}
@@ -330,7 +390,6 @@ const PromoteRow = ({ entry, draft, onChange, onOmit }: PromoteRowProps) => {
                             "data-testid": `promote-row-expiry-${entry.name}`,
                         },
                     }}
-                    sx={{ flex: 1 }}
                 />
             </Stack>
         </Box>

--- a/docs/superpowers/specs/2026-06-02-promote-adjust-quantity-design.md
+++ b/docs/superpowers/specs/2026-06-02-promote-adjust-quantity-design.md
@@ -1,0 +1,50 @@
+# Promote-to-inventory: editable quantity
+
+**Date:** 2026-06-02
+**Status:** Approved
+**Scope:** Frontend-only (`Frigorino.Web/ClientApp`)
+
+## Problem
+
+Client feedback on the promote-to-inventory feature: when reviewing items to add to
+inventory, the quantity is shown read-only (carried straight from the source list item).
+But the real-world quantity often differs from what was on the list — the store had fewer
+items, or you bought more than requested. Without the ability to adjust it during promote,
+the inventory drifts from reality and is hard to keep correct.
+
+## Solution
+
+Make the per-row quantity editable in the promote review sheet
+(`features/lists/promote/PromoteReviewSheet.tsx`), reusing the existing quantity-editing
+primitives. No API, DTO, or DB change — `CreateInventoryItem` already accepts a `quantity`.
+
+### Changes
+
+1. **Row draft gains a quantity field.** `RowDraft` becomes
+   `{ selected, expiry, quantity: QuantityDraft }`. Seeded with the existing
+   `quantityToDraft(entry.quantity)` helper. For a quantity-less item this yields
+   `EMPTY_QUANTITY_DRAFT`, which `draftToQuantity` converts back to `null` — so those
+   items behave exactly as before.
+
+2. **Inline editor, only for items that already have a quantity.** The read-only
+   quantity `<Chip>` is replaced by an inline value `TextField` + unit-select `TextField`
+   pair (same controls as the composer's `QuantityPanel`: `inputMode="decimal"`,
+   comma→dot tolerance, `QUANTITY_UNIT_VALUES` for the unit dropdown). The block renders
+   only when `entry.quantity` is truthy; quantity-less rows show no quantity field. The
+   now-unused `formatQuantity` import is removed.
+
+3. **Send the edited quantity.** `handleAdd` sends `draftToQuantity(draft.quantity)`
+   instead of `entry.quantity`.
+
+4. **Validation mirrors the composer.** Reuse `isDraftValid`. A new
+   `hasRowInvalidQuantity` guard (alongside `hasRowMissingDate`) disables the **Add**
+   button when any *selected* row holds a non-empty, unparseable/non-positive quantity.
+   Empty stays valid (= clears the quantity), matching composer semantics.
+
+## Testing
+
+No JS test runner exists and the change is frontend-only; per client direction no
+automated test is added for this case. Verification is manual via the dev stack /
+Playwright: adjust a row's quantity up and down and confirm the created inventory item
+reflects the edited value. The existing `Promote.feature` IT is unaffected (it does not
+assert quantity values).


### PR DESCRIPTION
## Summary

Client feedback on the promote-to-inventory feature: when reviewing items to add to inventory, the quantity was read-only (carried straight from the source list item). But the real quantity often differs — the store had fewer items, or you bought more than the list requested — so the inventory drifted from reality and was hard to keep correct.

This makes the per-row quantity **editable** in the promote review sheet.

## Changes

- `RowDraft` gains a `quantity: QuantityDraft` field, seeded via `quantityToDraft(entry.quantity)`.
- The read-only quantity chip is replaced by an inline **value field + unit dropdown**, reusing the composer's quantity primitives (`inputMode="decimal"`, comma→dot tolerance, `QUANTITY_UNIT_VALUES`). It renders **only for items that already have a quantity**; quantity-less rows are unchanged. Quantity sits on its own line above the full-width expiry field.
- `handleAdd` sends `draftToQuantity(draft.quantity)` so inventory reflects the edited amount.
- New `hasRowInvalidQuantity` guard disables **Add** when a selected row holds a non-empty, unparseable/non-positive quantity (empty = clear, matching composer semantics).
- Removed now-unused `formatQuantity` / `ShoppingBag` imports.
- Added `common.unit` ("Unit" / "Einheit") to en + de.

Frontend-only — `CreateInventoryItem` already accepts `quantity`; no API/DTO/DB change.

## Testing

- `npm run tsc`, `npm run lint`, `prettier --check` all pass.
- No automated test added (no JS test runner; per client direction for this case).
- Verified manually in the running app.

Spec: `docs/superpowers/specs/2026-06-02-promote-adjust-quantity-design.md`