### PR TITLE
feat: align dashboard chips and unify item quantity chip

### DIFF
--- a/Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
+++ b/Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
@@ -238,10 +238,10 @@
         "Kilogram": "kg",
         "Milliliter": "ml",
         "Liter": "l",
-        "Piece": "Stk",
-        "Pack": "Pack",
-        "Can": "Dose",
-        "Bottle": "Flasche",
+        "Piece": "Stück",
+        "Pack": "Packungen",
+        "Can": "Dosen",
+        "Bottle": "Flaschen",
         "Bag": "Beutel"
     },
     "dashboard": {
@@ -263,21 +263,21 @@
         "checkedItemRetentionDays": "Erledigte Einträge behalten (Tage)",
         "checkedItemRetentionHelp": "Tage, die erledigte Listeneinträge aufbewahrt werden, bevor sie entfernt werden.",
         "inventorySettings": "Inventareinstellungen",
-        "expiryLeadOverride": "Meine Vorlaufzeit überschreiben",
+        "expiryLeadOverride": "Meine Benachrichtigungszeitfenster überschreiben",
         "expiryLeadDays": "Vorlaufzeit (Tage)",
         "expiryLeadHelp": "Tage vor Ablauf, an denen ich für dieses Inventar erinnert werde.",
         "saved": "Einstellungen gespeichert",
         "saveFailed": "Einstellungen konnten nicht gespeichert werden",
         "readOnlyHint": "Nur Eigentümer und Admins können dies ändern.",
         "notifications": "Benachrichtigungen",
-        "notificationsEnable": "Ablauf-Erinnerungen",
-        "notificationsLeadDays": "Standard-Vorlaufzeit (Tage)",
-        "notificationsLeadHelp": "Tage vor Ablauf benachrichtigen, sofern ein Inventar dies nicht überschreibt.",
+        "notificationsEnable": "Benachrichtigungen vor erreichen des Ablaufdatums",
+        "notificationsLeadDays": "Benachrichtigungs Zeitfenster",
+        "notificationsLeadHelp": "Tage vor Ablauf benachrichtigen.",
         "notificationsPermissionDenied": "Benachrichtigungsberechtigung wurde verweigert.",
         "notificationsToggleFailed": "Benachrichtigungen konnten nicht aktualisiert werden. Prüfe die Benachrichtigungsberechtigung deines Browsers und versuche es erneut.",
         "notificationsIosHint": "Füge Frigorino zum Startbildschirm hinzu, um Benachrichtigungen auf iOS zu aktivieren.",
-        "notificationsBlockedHint": "Benachrichtigungen sind in deinen Browser-Einstellungen blockiert. Aktiviere sie für diese Seite wieder, um Ablauf-Erinnerungen zu erhalten.",
+        "notificationsBlockedHint": "Benachrichtigungen sind in deinen Browser-Einstellungen blockiert. Aktiviere sie für diese Seite wieder, um Benachrichtigungen zu erhalten.",
         "inventoryNotificationsEnable": "Mich über dieses Inventar benachrichtigen",
-        "inventoryNotificationsRequiresGlobal": "Ablauf-Erinnerungen sind in deinen Benutzereinstellungen deaktiviert — aktiviere sie dort, um diese tatsächlich zu erhalten."
+        "inventoryNotificationsRequiresGlobal": "Benachrichtigungen sind in deinen Benutzereinstellungen deaktiviert — aktiviere sie dort, um diese tatsächlich zu erhalten."
     }
 }

--- a/Application/Frigorino.Web/ClientApp/public/locales/en/translation.json
+++ b/Application/Frigorino.Web/ClientApp/public/locales/en/translation.json
@@ -239,10 +239,10 @@
         "Milliliter": "ml",
         "Liter": "l",
         "Piece": "pc",
-        "Pack": "pack",
-        "Can": "can",
-        "Bottle": "bottle",
-        "Bag": "bag"
+        "Pack": "packs",
+        "Can": "cans",
+        "Bottle": "bottles",
+        "Bag": "bags"
     },
     "dashboard": {
         "items": "Items",

--- a/Application/Frigorino.Web/ClientApp/src/components/common/ItemQuantityChip.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/common/ItemQuantityChip.tsx
@@ -1,0 +1,27 @@
+import { Chip } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { formatQuantity } from "../composer";
+import type { QuantityDto } from "../../lib/api";
+
+interface Props {
+    quantity: QuantityDto;
+    // When provided, tapping the chip triggers an edit affordance (e.g. open the quantity panel).
+    onClick?: () => void;
+    testId?: string;
+}
+
+// Shared quantity chip used by both list items and inventory items so their
+// quantity rendering stays consistent. Outlined, compact (h20).
+export function ItemQuantityChip({ quantity, onClick, testId }: Props) {
+    const { t } = useTranslation();
+    return (
+        <Chip
+            size="small"
+            variant="outlined"
+            data-testid={testId}
+            label={formatQuantity(t, quantity)}
+            onClick={onClick}
+            sx={{ height: 20 }}
+        />
+    );
+}

--- a/Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx
@@ -470,76 +470,64 @@ export const WelcomePage = () => {
                                                     }
                                                 >
                                                     <ListItemText
+                                                        sx={{ my: 0 }}
                                                         primary={
-                                                            <Box
+                                                            <Typography
+                                                                variant="body2"
                                                                 sx={{
-                                                                    display:
-                                                                        "flex",
-                                                                    justifyContent:
-                                                                        "space-between",
-                                                                    alignItems:
-                                                                        "center",
+                                                                    fontWeight: 500,
                                                                 }}
                                                             >
-                                                                <Typography
-                                                                    variant="body2"
-                                                                    sx={{
-                                                                        fontWeight: 500,
-                                                                    }}
-                                                                >
-                                                                    {item.name}
-                                                                </Typography>
-                                                                <Box
-                                                                    sx={{
-                                                                        display:
-                                                                            "flex",
-                                                                        alignItems:
-                                                                            "center",
-                                                                        gap: 0.5,
-                                                                    }}
-                                                                >
-                                                                    {"expiryChip" in
-                                                                        item &&
-                                                                        item.expiryChip && (
-                                                                            <Chip
-                                                                                label={
-                                                                                    item
-                                                                                        .expiryChip
-                                                                                        .label
-                                                                                }
-                                                                                size="small"
-                                                                                variant="outlined"
-                                                                                sx={{
-                                                                                    fontSize:
-                                                                                        "0.7rem",
-                                                                                    height: 20,
-                                                                                    color: item
-                                                                                        .expiryChip
-                                                                                        .color,
-                                                                                    borderColor:
-                                                                                        item
-                                                                                            .expiryChip
-                                                                                            .color,
-                                                                                }}
-                                                                            />
-                                                                        )}
-                                                                    <Chip
-                                                                        label={
-                                                                            item.count
-                                                                        }
-                                                                        size="small"
-                                                                        variant="outlined"
-                                                                        sx={{
-                                                                            fontSize:
-                                                                                "0.7rem",
-                                                                            height: 20,
-                                                                        }}
-                                                                    />
-                                                                </Box>
-                                                            </Box>
+                                                                {item.name}
+                                                            </Typography>
                                                         }
                                                         secondary={item.status}
                                                     />
+                                                    <Box
+                                                        sx={{
+                                                            display: "flex",
+                                                            alignItems:
+                                                                "center",
+                                                            gap: 0.5,
+                                                            flexShrink: 0,
+                                                            ml: 1,
+                                                        }}
+                                                    >
+                                                        {"expiryChip" in item &&
+                                                            item.expiryChip && (
+                                                                <Chip
+                                                                    label={
+                                                                        item
+                                                                            .expiryChip
+                                                                            .label
+                                                                    }
+                                                                    size="small"
+                                                                    variant="outlined"
+                                                                    sx={{
+                                                                        fontSize:
+                                                                            "0.7rem",
+                                                                        height: 20,
+                                                                        color: item
+                                                                            .expiryChip
+                                                                            .color,
+                                                                        borderColor:
+                                                                            item
+                                                                                .expiryChip
+                                                                                .color,
+                                                                    }}
+                                                                />
+                                                            )}
+                                                        <Chip
+                                                            label={item.count}
+                                                            size="small"
+                                                            variant="outlined"
+                                                            sx={{
+                                                                fontSize:
+                                                                    "0.7rem",
+                                                                height: 20,
+                                                            }}
+                                                        />
+                                                    </Box>
                                                 </ListItem>
                                             );
                                         })}

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/items/components/InventoryItemContent.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/items/components/InventoryItemContent.tsx
@@ -1,4 +1,3 @@
-import { ShoppingBag } from "@mui/icons-material";
 import {
     Box,
     ListItemText,
@@ -9,7 +8,7 @@ import {
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { formatQuantity } from "../../../../components/composer";
+import { ItemQuantityChip } from "../../../../components/common/ItemQuantityChip";
 import { useLongPress } from "../../../../hooks/useLongPress";
 import type { InventoryItemResponse } from "../../../../lib/api";
 import {
@@ -90,18 +89,10 @@ export function InventoryItemContent({ item }: Props) {
                         {/* Left side - Quantity */}
                         <Box>
                             {item.quantity && (
-                                <Typography
-                                    variant="caption"
-                                    data-testid={`inventory-item-quantity-${item.text}`}
-                                    sx={{
-                                        display: "flex",
-                                        alignItems: "center",
-                                        gap: 0.5,
-                                    }}
-                                >
-                                    <ShoppingBag fontSize="small" />
-                                    {formatQuantity(t, item.quantity)}
-                                </Typography>
+                                <ItemQuantityChip
+                                    quantity={item.quantity}
+                                    testId={`inventory-item-quantity-${item.text}`}
+                                />
                             )}
                         </Box>
 

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListItemContent.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListItemContent.tsx
@@ -1,7 +1,7 @@
-import { Box, Chip, Link, ListItemText, Typography } from "@mui/material";
+import { Box, Link, ListItemText, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { formatQuantity } from "../../../../components/composer";
+import { ItemQuantityChip } from "../../../../components/common/ItemQuantityChip";
 import { useLongPress } from "../../../../hooks/useLongPress";
 import type { ListItemResponse } from "../../../../lib/api";
 
@@ -47,15 +47,10 @@ export function ListItemContent({ item, onEditQuantity }: Props) {
                             gap: 0.5,
                         }}
                     >
-                        <Chip
-                            size="small"
-                            variant="outlined"
-                            data-testid={`list-item-quantity-${item.text}`}
-                            label={formatQuantity(t, item.quantity)}
+                        <ItemQuantityChip
+                            quantity={item.quantity}
                             onClick={onEditQuantity}
-                            sx={{
-                                height: 20,
-                            }}
+                            testId={`list-item-quantity-${item.text}`}
                         />
                     </Box>
                 ) : null


### PR DESCRIPTION
## Summary
UI alignment polish plus translation refinements.

### 1. Dashboard chip/text alignment
Summary chips ("X offen", "Y Artikel", expiry) lived inside `ListItemText.primary`, anchoring them to the name's top line while the summary text sat on the line below — looking top-heavy. Moved them into a `flexShrink: 0` flex sibling so the name + status stack on the left and the chips are vertically centered against the full row (via `ListItem`'s default `align-items: center`).

### 2. Unified item quantity chip
New shared `components/common/ItemQuantityChip.tsx` (outlined, `height: 20`, optional `onClick`, passthrough `testId`), now used by **both** `ListItemContent` and `InventoryItemContent`. Inventory dropped its `Typography` + `ShoppingBag` rendering and matches the list item by construction. Existing test IDs preserved (`list-item-quantity-*`, `inventory-item-quantity-*`).

### 3. i18n
- Pluralized unit labels: en `packs/cans/bottles/bags`, de `Stück/Packungen/Dosen/Flaschen`.
- Refined notification-settings wording in de.

## Verification
- `npm run tsc` ✅
- `npm run lint` ✅
- `npm run prettier` ✅
- Browser verify skipped (isolated dev stack couldn't build — local VS/running app held DLL locks). Changes are frontend-only and idiomatic.

> Note: IT harness serves `ClientApp/build`; run `npm run build` before any integration run to pick up the new markup.