### PR TITLE
fix(it): deflake undo-delete-toast integration tests

### DIFF
--- a/Application/Frigorino.IntegrationTests/Shared/ToastSteps.cs
+++ b/Application/Frigorino.IntegrationTests/Shared/ToastSteps.cs
@@ -13,9 +13,21 @@ public class ToastSteps(ScenarioContextHolder ctx)
             && r.Url.EndsWith("/restore")
             && r.Request.Method == "POST"
             && r.Status == 200);
-        await Assertions.Expect(ctx.Page.Locator("[data-sonner-toast] .undo-action-button"))
-            .ToBeVisibleAsync();
-        await ctx.Page.Locator("[data-sonner-toast] .undo-action-button").ClickAsync();
+
+        var toast = ctx.Page.Locator("[data-sonner-toast]");
+        var undoButton = toast.Locator(".undo-action-button");
+
+        // The toast auto-dismisses after its sonner `duration` (5s). Under load the test can
+        // reach the click just as the toast begins its dismiss transition: the button is still
+        // hit-testable but its pointer-events are disabled, so the click is silently swallowed,
+        // the restore POST never fires, and the wait above hangs the full timeout (the observed
+        // intermittent failure). Hovering the toast pauses sonner's auto-dismiss timer
+        // (expanded/interacting => pauseTimer) for as long as the pointer stays over it, so the
+        // subsequent click no longer races the timer.
+        await Assertions.Expect(toast).ToBeVisibleAsync();
+        await toast.HoverAsync();
+        await Assertions.Expect(undoButton).ToBeVisibleAsync();
+        await undoButton.ClickAsync();
         await responseTask;
     }
 }


### PR DESCRIPTION
## Problem
The `Undo restores a deleted ... item via the toast` integration scenarios (inventory **and** list — they share `Shared/ToastSteps.cs`) timed out intermittently. Failure signature: `Timeout 30000ms exceeded while waiting for event "Response"` — the hang was on the `await responseTask` (WaitForResponse for the `/restore` POST), **not** on the click.

## Root cause
The sonner toast auto-dismisses after `duration: 5000`. Under Testcontainers load the test reached the undo click during the toast's dismiss transition — the button is still hit-testable but its `pointer-events` are disabled, so the click was **silently swallowed**, the restore POST never fired, and the response wait hung the full timeout.

Ruled out during diagnosis:
- **Response predicate mismatch** — route is `POST .../items/{id}/restore` → 200, matches the predicate exactly.
- **React Query invalidation race** — `invalidateQueries` defaults `cancelRefetch: true`, and the final assertion retries.
- **Stale/duplicate toast** — `ScenarioHooks` gives a fresh `BrowserContext` + `Page` per scenario.

## Fix
Hover the toast before clicking undo. Sonner pauses its auto-dismiss timer while the toast is hovered (`expanded`/`interacting` ⇒ `pauseTimer`), so the click no longer races the 5s timer. **Test-only change — production toast duration is unchanged.**

## Verification
9 consecutive runs of both undo scenarios — **18 scenario executions, 0 failures**.