### PR TITLE
WhatsApp-style composer + toast theming

### DIFF
--- a/Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
+++ b/Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
@@ -38,7 +38,6 @@
         "errorOccurred": "Ein Fehler ist aufgetreten",
         "nameRequired": "Name ist erforderlich",
         "goBackToDashboard": "Zurück zum Dashboard",
-        "discardInput": "Eingabe verwerfen",
         "selectHouseholdFirst": "Sie müssen zuerst einen Haushalt auswählen",
         "current": "Aktuell",
         "overview": "Übersicht",

--- a/Application/Frigorino.Web/ClientApp/public/locales/en/translation.json
+++ b/Application/Frigorino.Web/ClientApp/public/locales/en/translation.json
@@ -38,7 +38,6 @@
         "errorOccurred": "An error occurred",
         "nameRequired": "Name is required",
         "goBackToDashboard": "Go back to dashboard",
-        "discardInput": "Discard input",
         "selectHouseholdFirst": "You need to select a household first",
         "current": "Current",
         "overview": "Overview",

--- a/Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx
@@ -1,4 +1,4 @@
-import { Box, Collapse, Paper } from "@mui/material";
+import { Box, Collapse } from "@mui/material";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ComposerTextField } from "./components/ComposerTextField";
@@ -165,21 +165,11 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
         (isEditing ? t("common.editItem") : t("common.addItemPlaceholder"));
 
     return (
-        <Paper
-            elevation={3}
+        <Box
             onClick={handleContainerClick}
             sx={{
                 width: "100%",
-                p: 1,
-                bgcolor: "background.paper",
-                border: "1px solid",
-                borderColor: isEditing ? "warning.main" : "primary.200",
                 cursor: "text",
-                transition: "all 0.3s ease",
-                "&:hover, &:focus-within": {
-                    borderColor: isEditing ? "warning.dark" : "primary.main",
-                    boxShadow: 3,
-                },
             }}
         >
             {isEditing && editing && (
@@ -242,6 +232,16 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
                         bgcolor: "action.hover",
                         // Pill shape (≈12px). Distinct from card radius on purpose.
                         borderRadius: 3,
+                        // The pill is the input surface now (no outer card), so it
+                        // carries the edit/focus highlight border.
+                        border: "1px solid",
+                        borderColor: isEditing ? "warning.main" : "primary.200",
+                        transition: "border-color 0.2s ease",
+                        "&:hover, &:focus-within": {
+                            borderColor: isEditing
+                                ? "warning.dark"
+                                : "primary.main",
+                        },
                         // Inline icons read as in-field adornments, not standalone
                         // 44px buttons — overrides the per-feature minWidth/minHeight.
                         "& .MuiButtonBase-root": {
@@ -298,6 +298,6 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
                     duplicate={Boolean(dup)}
                 />
             </Box>
-        </Paper>
+        </Box>
     );
 }

--- a/Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx
@@ -1,5 +1,5 @@
 import { Box, Collapse } from "@mui/material";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ComposerTextField } from "./components/ComposerTextField";
 import { EditHeader } from "./components/EditHeader";
@@ -116,6 +116,20 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
         editing?.onCancel();
         focusInput();
     };
+
+    // When entering edit mode, focus the field so editing can start immediately and
+    // the mobile keyboard opens. The composer is remounted per edited item (keyed by
+    // id in the footer), so this runs once on entering edit. Skipped when a modifier
+    // panel is opened instead (e.g. editing a comment/quantity via its chip) so we
+    // don't pull focus from that panel, and skipped in add mode so the keyboard
+    // doesn't pop open on every list load. rAF lets the input mount before focusing.
+    useEffect(() => {
+        if (!isEditing || initialOpenId) {
+            return;
+        }
+        const raf = requestAnimationFrame(focusInput);
+        return () => cancelAnimationFrame(raf);
+    }, [isEditing, initialOpenId, focusInput]);
 
     const handleContainerClick = (event: React.MouseEvent) => {
         if ((event.target as HTMLElement).closest(".composer-panel")) {

--- a/Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx
@@ -1,5 +1,4 @@
-import { Delete } from "@mui/icons-material";
-import { Box, Collapse, IconButton, Paper } from "@mui/material";
+import { Box, Collapse, Paper } from "@mui/material";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ComposerTextField } from "./components/ComposerTextField";
@@ -111,11 +110,6 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
         },
         [onComplete, reset],
     );
-
-    const handleDiscard = () => {
-        reset();
-        focusInput();
-    };
 
     const handleCancelEdit = () => {
         reset();
@@ -236,62 +230,64 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
             )}
 
             <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                {trimmed && !isEditing && (
-                    <IconButton
-                        onClick={handleDiscard}
-                        title={t("common.discardInput")}
-                        aria-label={t("common.discardInput")}
-                        sx={{
-                            minWidth: 44,
-                            minHeight: 44,
-                            color: "text.secondary",
-                            bgcolor: "action.hover",
-                            "&:hover": {
-                                color: "error.main",
-                                bgcolor: "error.50",
-                            },
-                        }}
-                    >
-                        <Delete />
-                    </IconButton>
-                )}
+                <Box
+                    sx={{
+                        flex: 1,
+                        minWidth: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.25,
+                        pl: 1.5,
+                        pr: 0.5,
+                        bgcolor: "action.hover",
+                        // Pill shape (≈12px). Distinct from card radius on purpose.
+                        borderRadius: 3,
+                        // Inline icons read as in-field adornments, not standalone
+                        // 44px buttons — overrides the per-feature minWidth/minHeight.
+                        "& .MuiButtonBase-root": {
+                            minWidth: 38,
+                            minHeight: 38,
+                        },
+                    }}
+                >
+                    <ComposerTextField
+                        text={text}
+                        onTextChange={setText}
+                        onEnter={completeText}
+                        inputRef={inputRef}
+                        placeholder={fieldPlaceholder}
+                        disabled={disabled}
+                        errorMessage={dup?.message}
+                        suggestions={suggestions}
+                    />
 
-                {modifierFeatures.map((feature) =>
-                    feature.renderToggle ? (
-                        <Box
-                            key={feature.id}
-                            className="composer-panel"
-                            data-testid={`composer-toggle-${feature.id}`}
-                            onMouseDown={preventInputBlur}
-                        >
-                            {feature.renderToggle(slotFor(feature))}
-                        </Box>
-                    ) : null,
-                )}
+                    {modifierFeatures.map((feature) =>
+                        feature.renderToggle ? (
+                            <Box
+                                key={feature.id}
+                                className="composer-panel"
+                                data-testid={`composer-toggle-${feature.id}`}
+                                onMouseDown={preventInputBlur}
+                            >
+                                {feature.renderToggle(slotFor(feature))}
+                            </Box>
+                        ) : null,
+                    )}
 
-                {actionFeatures.map((feature) => (
-                    <Box key={feature.id} className="composer-panel">
-                        {feature.renderTrigger({
-                            complete: (payload) =>
-                                completeAction(
-                                    feature.id,
-                                    payload as Record<string, unknown>,
-                                ),
-                            disabled,
-                        })}
-                    </Box>
-                ))}
-
-                <ComposerTextField
-                    text={text}
-                    onTextChange={setText}
-                    onEnter={completeText}
-                    inputRef={inputRef}
-                    placeholder={fieldPlaceholder}
-                    disabled={disabled}
-                    errorMessage={dup?.message}
-                    suggestions={suggestions}
-                />
+                    {!trimmed &&
+                        actionFeatures.map((feature) => (
+                            <Box key={feature.id} className="composer-panel">
+                                {feature.renderTrigger({
+                                    complete: (payload) =>
+                                        completeAction(
+                                            feature.id,
+                                            payload as Record<string, unknown>,
+                                        ),
+                                    disabled,
+                                })}
+                            </Box>
+                        ))}
+                </Box>
 
                 <SendButton
                     onClick={completeText}

--- a/Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx
@@ -124,10 +124,20 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
         focusInput();
     };
 
-    // Tapping a panel toggle/chip must not blur the text input — on mobile a blur
-    // collapses the soft keyboard. preventDefault on mousedown keeps focus where it
-    // is while still firing the click that opens/closes the panel.
-    const preventInputBlur = (event: React.MouseEvent) => {
+    // Keep the mobile soft keyboard open. Tapping any non-input control inside the
+    // composer (icon buttons, chips, padding) would by default move focus off the
+    // focused text field and collapse the keyboard, making the layout jump.
+    // preventDefault on mousedown keeps focus where it is while still firing the
+    // control's click. Real text inputs (the field, the comment textarea) are
+    // excluded so they can take focus normally.
+    const keepKeyboardOpen = (event: React.MouseEvent) => {
+        const target = event.target as HTMLElement;
+        const isTextInput = target.closest(
+            "input, textarea, [contenteditable='true']",
+        );
+        if (isTextInput) {
+            return;
+        }
         event.preventDefault();
     };
 
@@ -167,6 +177,7 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
     return (
         <Box
             onClick={handleContainerClick}
+            onMouseDown={keepKeyboardOpen}
             sx={{
                 width: "100%",
                 cursor: "text",
@@ -190,7 +201,6 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
                             key={feature.id}
                             className="composer-panel"
                             data-testid={`composer-chip-${feature.id}`}
-                            onMouseDown={preventInputBlur}
                             sx={{
                                 display: "inline-flex",
                                 alignItems: "center",
@@ -267,7 +277,6 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
                                 key={feature.id}
                                 className="composer-panel"
                                 data-testid={`composer-toggle-${feature.id}`}
-                                onMouseDown={preventInputBlur}
                             >
                                 {feature.renderToggle(slotFor(feature))}
                             </Box>

--- a/Application/Frigorino.Web/ClientApp/src/components/composer/features/attachComposerFeature.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/composer/features/attachComposerFeature.tsx
@@ -7,11 +7,15 @@ import {
     PhotoCamera,
 } from "@mui/icons-material";
 import {
+    ClickAwayListener,
+    Grow,
     IconButton,
     ListItemIcon,
     ListItemText,
-    Menu,
     MenuItem,
+    MenuList,
+    Paper,
+    Popper,
 } from "@mui/material";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -30,6 +34,7 @@ const AttachTrigger = ({
     const { t } = useTranslation();
     const [anchor, setAnchor] = useState<null | HTMLElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const open = Boolean(anchor);
 
     const handlePick = (event: React.ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
@@ -58,57 +63,94 @@ const AttachTrigger = ({
         input.click();
     };
 
+    const handleClickAway = (event: MouseEvent | TouchEvent) => {
+        // The trigger button's own click toggles the menu; ignore it here so the
+        // open click isn't immediately treated as a click-away.
+        if (anchor && anchor.contains(event.target as Node)) {
+            return;
+        }
+        setAnchor(null);
+    };
+
     return (
         <>
             <IconButton
-                onClick={(e) => setAnchor(e.currentTarget)}
+                onClick={(e) => setAnchor(anchor ? null : e.currentTarget)}
                 disabled={disabled}
                 aria-label={t("lists.attach")}
+                aria-haspopup="true"
+                aria-expanded={open ? "true" : undefined}
+                aria-controls={open ? "composer-attach-menu" : undefined}
                 data-testid="composer-attach-button"
                 sx={{ minWidth: 44, minHeight: 44 }}
             >
                 <AddPhotoAlternate fontSize="small" />
             </IconButton>
 
-            {/* Keep the mobile soft keyboard open: by default MUI's Menu focuses
-                itself (autoFocus) and the active item (autoFocusItem) on open, and
-                traps/restores focus — each of which blurs the composer field. Disable
-                all of them so the field keeps focus while the menu is up. */}
-            <Menu
+            {/* A non-modal Popper, NOT a Menu: a Menu is Modal-based and marks the rest
+                of the page aria-hidden on open, which blurs the focused composer field
+                and collapses the mobile soft keyboard. A Popper doesn't trap focus or
+                aria-hide the page, and MenuList with autoFocusItem off never pulls focus,
+                so the keyboard stays up. */}
+            <Popper
+                open={open}
                 anchorEl={anchor}
-                open={Boolean(anchor)}
-                onClose={() => setAnchor(null)}
-                autoFocus={false}
-                disableAutoFocusItem
-                disableEnforceFocus
-                disableRestoreFocus
+                placement="top-start"
+                transition
+                sx={{ zIndex: (theme) => theme.zIndex.modal }}
             >
-                <MenuItem
-                    data-testid="composer-attach-camera"
-                    onClick={() => openPicker(true)}
-                >
-                    <ListItemIcon>
-                        <PhotoCamera fontSize="small" />
-                    </ListItemIcon>
-                    <ListItemText>{t("lists.takePhoto")}</ListItemText>
-                </MenuItem>
-                <MenuItem
-                    data-testid="composer-attach-photo"
-                    onClick={() => openPicker(false)}
-                >
-                    <ListItemIcon>
-                        <Image fontSize="small" />
-                    </ListItemIcon>
-                    <ListItemText>{t("lists.choosePhoto")}</ListItemText>
-                </MenuItem>
-                {/* Document arrives in sub-feature #3. */}
-                <MenuItem disabled data-testid="composer-attach-document">
-                    <ListItemIcon>
-                        <Description fontSize="small" />
-                    </ListItemIcon>
-                    <ListItemText>{t("lists.attachDocument")}</ListItemText>
-                </MenuItem>
-            </Menu>
+                {({ TransitionProps }) => (
+                    <Grow
+                        {...TransitionProps}
+                        style={{ transformOrigin: "left bottom" }}
+                    >
+                        <Paper elevation={3}>
+                            <ClickAwayListener onClickAway={handleClickAway}>
+                                <MenuList
+                                    id="composer-attach-menu"
+                                    autoFocusItem={false}
+                                    disablePadding
+                                >
+                                    <MenuItem
+                                        data-testid="composer-attach-camera"
+                                        onClick={() => openPicker(true)}
+                                    >
+                                        <ListItemIcon>
+                                            <PhotoCamera fontSize="small" />
+                                        </ListItemIcon>
+                                        <ListItemText>
+                                            {t("lists.takePhoto")}
+                                        </ListItemText>
+                                    </MenuItem>
+                                    <MenuItem
+                                        data-testid="composer-attach-photo"
+                                        onClick={() => openPicker(false)}
+                                    >
+                                        <ListItemIcon>
+                                            <Image fontSize="small" />
+                                        </ListItemIcon>
+                                        <ListItemText>
+                                            {t("lists.choosePhoto")}
+                                        </ListItemText>
+                                    </MenuItem>
+                                    {/* Document arrives in sub-feature #3. */}
+                                    <MenuItem
+                                        disabled
+                                        data-testid="composer-attach-document"
+                                    >
+                                        <ListItemIcon>
+                                            <Description fontSize="small" />
+                                        </ListItemIcon>
+                                        <ListItemText>
+                                            {t("lists.attachDocument")}
+                                        </ListItemText>
+                                    </MenuItem>
+                                </MenuList>
+                            </ClickAwayListener>
+                        </Paper>
+                    </Grow>
+                )}
+            </Popper>
 
             {/* `capture` is set/cleared imperatively in openPicker() before .click(); no static
                 attribute here so the default (file/gallery picker) applies. */}

--- a/Application/Frigorino.Web/ClientApp/src/components/composer/features/attachComposerFeature.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/composer/features/attachComposerFeature.tsx
@@ -70,14 +70,16 @@ const AttachTrigger = ({
                 <AddPhotoAlternate fontSize="small" />
             </IconButton>
 
-            {/* Keep the mobile soft keyboard open: by default MUI's Menu moves focus
-                into itself on open, blurring the composer field. These disable the
-                focus grab/trap/restore so the field keeps focus while the menu is up. */}
+            {/* Keep the mobile soft keyboard open: by default MUI's Menu focuses
+                itself (autoFocus) and the active item (autoFocusItem) on open, and
+                traps/restores focus — each of which blurs the composer field. Disable
+                all of them so the field keeps focus while the menu is up. */}
             <Menu
                 anchorEl={anchor}
                 open={Boolean(anchor)}
                 onClose={() => setAnchor(null)}
-                disableAutoFocus
+                autoFocus={false}
+                disableAutoFocusItem
                 disableEnforceFocus
                 disableRestoreFocus
             >

--- a/Application/Frigorino.Web/ClientApp/src/components/composer/features/attachComposerFeature.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/composer/features/attachComposerFeature.tsx
@@ -70,10 +70,16 @@ const AttachTrigger = ({
                 <AddPhotoAlternate fontSize="small" />
             </IconButton>
 
+            {/* Keep the mobile soft keyboard open: by default MUI's Menu moves focus
+                into itself on open, blurring the composer field. These disable the
+                focus grab/trap/restore so the field keeps focus while the menu is up. */}
             <Menu
                 anchorEl={anchor}
                 open={Boolean(anchor)}
                 onClose={() => setAnchor(null)}
+                disableAutoFocus
+                disableEnforceFocus
+                disableRestoreFocus
             >
                 <MenuItem
                     data-testid="composer-attach-camera"

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/items/components/InventoryFooter.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/items/components/InventoryFooter.tsx
@@ -116,7 +116,7 @@ export const InventoryFooter = memo(
                 sx={{
                     flexShrink: 0,
                     px: 3,
-                    py: 2,
+                    py: 1,
                     borderTop: 1,
                     borderColor: "divider",
                     bgcolor: "background.paper",

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListFooter.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListFooter.tsx
@@ -170,7 +170,7 @@ export const ListFooter = memo(
                 sx={{
                     flexShrink: 0,
                     px: 3,
-                    py: 2,
+                    py: 1,
                     borderTop: 1,
                     borderColor: "divider",
                     bgcolor: "background.paper",

--- a/Application/Frigorino.Web/ClientApp/src/main.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/main.tsx
@@ -84,6 +84,7 @@ createRoot(document.getElementById("root")!).render(
                     <RouterProvider router={router} />
                 </Suspense>
                 <Toaster
+                    closeButton
                     toastOptions={{
                         classNames: { actionButton: "undo-action-button" },
                     }}

--- a/Application/Frigorino.Web/ClientApp/src/main.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/main.tsx
@@ -32,6 +32,7 @@ import {
     Box,
     CircularProgress,
     CssBaseline,
+    GlobalStyles,
     ThemeProvider,
 } from "@mui/material";
 import { Toaster } from "sonner";
@@ -83,7 +84,49 @@ createRoot(document.getElementById("root")!).render(
                 >
                     <RouterProvider router={router} />
                 </Suspense>
+                {/* Theme sonner to match the app: dark surfaces, green action
+                    button, and the close button pulled inline to the right instead
+                    of floating at the top-left corner. Driven by theme tokens (this
+                    sits inside ThemeProvider) so it tracks the palette. Selectors are
+                    scoped under [data-sonner-toaster] for specificity over sonner's
+                    own runtime-injected styles. */}
+                <GlobalStyles
+                    styles={(theme) => ({
+                        "[data-sonner-toaster]": {
+                            "--normal-bg": theme.palette.background.paper,
+                            "--normal-text": theme.palette.text.primary,
+                            "--normal-border": theme.palette.divider,
+                            "--success-bg": theme.palette.background.paper,
+                            "--success-text": theme.palette.text.primary,
+                            "--success-border": theme.palette.divider,
+                        },
+                        "[data-sonner-toaster] [data-sonner-toast]": {
+                            borderRadius: theme.shape.borderRadius,
+                        },
+                        "[data-sonner-toaster] [data-sonner-toast] [data-button]":
+                            {
+                                backgroundColor: theme.palette.primary.main,
+                                color: theme.palette.primary.contrastText,
+                            },
+                        "[data-sonner-toaster] [data-sonner-toast] [data-close-button]":
+                            {
+                                position: "static",
+                                order: 5,
+                                transform: "none",
+                                marginLeft: theme.spacing(1),
+                                background: "transparent",
+                                border: "none",
+                                color: theme.palette.text.secondary,
+                            },
+                        "[data-sonner-toaster] [data-sonner-toast] [data-close-button]:hover":
+                            {
+                                color: theme.palette.text.primary,
+                                backgroundColor: theme.palette.action.hover,
+                            },
+                    })}
+                />
                 <Toaster
+                    theme="dark"
                     closeButton
                     toastOptions={{
                         classNames: { actionButton: "undo-action-button" },

--- a/docs/superpowers/plans/2026-06-04-whatsapp-style-composer.md
+++ b/docs/superpowers/plans/2026-06-04-whatsapp-style-composer.md
@@ -1,0 +1,218 @@
+# WhatsApp-style Composer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the list/inventory input composer so the text field dominates the width — icons live inside a rounded input pill, the round send button sits outside, the discard button is gone, and action icons (attach) hide once the user starts typing.
+
+**Architecture:** A single-file change to the composer's bottom row in `Composer.tsx`, plus a dead-translation cleanup. The text field and icons get wrapped in a flex "pill" `Box`; the existing `SendButton` stays outside it. Visibility keys off the existing feature `kind` — `action` features render only while the field is empty, `modifier` features always render. No changes to feature descriptor types or any feature file.
+
+**Tech Stack:** React 19, MUI, TypeScript. **No JS unit-test runner exists in this repo** (per CLAUDE.md) — verification is `npm run tsc` + `npm run lint` + `npm run prettier`, the existing Playwright/Reqnroll integration tests (`dotnet test`), and a manual browser pass via the dev stack.
+
+---
+
+## File structure
+
+- **Modify:** `Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx` — restructure the bottom flex row into `[ pill: textfield + toggles + actions ] [ send ]`, gate action features on empty text, delete the discard `IconButton` and its `Delete` import.
+- **Modify:** `Application/Frigorino.Web/ClientApp/public/locales/en/translation.json` — remove the now-dead `common.discardInput` key.
+- **Modify:** `Application/Frigorino.Web/ClientApp/public/locales/de/translation.json` — remove the now-dead `common.discardInput` key.
+
+No feature files (`commentComposerFeature.tsx`, `attachComposerFeature.tsx`, `quantityComposerFeature.tsx`) change — inline icon sizing is overridden once, from the pill container.
+
+---
+
+### Task 1: Restructure the composer row into a pill
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx`
+
+- [ ] **Step 1: Remove the unused `Delete` import**
+
+In `Composer.tsx` line 1, delete this entire line:
+
+```tsx
+import { Delete } from "@mui/icons-material";
+```
+
+(After this task `Delete` is no longer referenced anywhere in the file.)
+
+- [ ] **Step 2: Replace the bottom row markup**
+
+Replace the entire final `<Box>…</Box>` block — the one that currently starts at
+`<Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>` (currently
+~line 238) and ends with the closing `</Box>` right before `</Paper>` (currently
+~line 304) — with the following. This deletes the discard `IconButton`, wraps the
+text field + toggles + actions in a pill, and renders action features only when
+the field is empty:
+
+```tsx
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <Box
+                    sx={{
+                        flex: 1,
+                        minWidth: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.25,
+                        pl: 1.5,
+                        pr: 0.5,
+                        bgcolor: "action.hover",
+                        // Pill shape (≈12px). Distinct from card radius on purpose.
+                        borderRadius: 3,
+                        // Inline icons read as in-field adornments, not standalone
+                        // 44px buttons — overrides the per-feature minWidth/minHeight.
+                        "& .MuiButtonBase-root": { minWidth: 38, minHeight: 38 },
+                    }}
+                >
+                    <ComposerTextField
+                        text={text}
+                        onTextChange={setText}
+                        onEnter={completeText}
+                        inputRef={inputRef}
+                        placeholder={fieldPlaceholder}
+                        disabled={disabled}
+                        errorMessage={dup?.message}
+                        suggestions={suggestions}
+                    />
+
+                    {modifierFeatures.map((feature) =>
+                        feature.renderToggle ? (
+                            <Box
+                                key={feature.id}
+                                className="composer-panel"
+                                data-testid={`composer-toggle-${feature.id}`}
+                                onMouseDown={preventInputBlur}
+                            >
+                                {feature.renderToggle(slotFor(feature))}
+                            </Box>
+                        ) : null,
+                    )}
+
+                    {!trimmed &&
+                        actionFeatures.map((feature) => (
+                            <Box key={feature.id} className="composer-panel">
+                                {feature.renderTrigger({
+                                    complete: (payload) =>
+                                        completeAction(
+                                            feature.id,
+                                            payload as Record<string, unknown>,
+                                        ),
+                                    disabled,
+                                })}
+                            </Box>
+                        ))}
+                </Box>
+
+                <SendButton
+                    onClick={completeText}
+                    disabled={
+                        !trimmed || disabled || blocked || !modifiersValid
+                    }
+                    editing={isEditing}
+                    duplicate={Boolean(dup)}
+                />
+            </Box>
+```
+
+Note: `actionFeatures`, `modifierFeatures`, `trimmed`, `completeAction`,
+`slotFor`, `preventInputBlur`, `ComposerTextField`, and `SendButton` are all
+already defined/imported in this file — only the markup changes.
+
+- [ ] **Step 3: Type-check**
+
+Run (from `Application/Frigorino.Web/ClientApp/`): `npm run tsc`
+Expected: PASS, no errors. (Confirms `Delete` removal left no dangling reference and the JSX is valid.)
+
+- [ ] **Step 4: Lint + format**
+
+Run (from `ClientApp/`): `npm run lint` then `npm run prettier`
+Expected: lint passes; prettier reformats the edited block if needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx
+git commit -m "feat(composer): WhatsApp-style pill layout; hide actions on type, drop discard button"
+```
+
+---
+
+### Task 2: Remove the dead `discardInput` translation key
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/public/locales/en/translation.json`
+- Modify: `Application/Frigorino.Web/ClientApp/public/locales/de/translation.json`
+
+- [ ] **Step 1: Delete the key from English**
+
+In `public/locales/en/translation.json`, delete line 41 (inside the `common`
+object):
+
+```json
+        "discardInput": "Discard input",
+```
+
+The preceding line (`"goBackToDashboard": …,`) keeps its trailing comma and the
+following line continues the object, so the JSON stays valid.
+
+- [ ] **Step 2: Delete the key from German**
+
+In `public/locales/de/translation.json`, delete line 41 (inside the `common`
+object):
+
+```json
+        "discardInput": "Eingabe verwerfen",
+```
+
+- [ ] **Step 3: Verify no remaining references**
+
+Run (from repo root): `grep -rn "discardInput" Application/Frigorino.Web/ClientApp/src Application/Frigorino.Web/ClientApp/public`
+Expected: no matches.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/public/locales/en/translation.json Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
+git commit -m "chore(i18n): remove dead common.discardInput key"
+```
+
+---
+
+### Task 3: Verify behaviour end-to-end
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build the SPA the integration harness serves**
+
+The integration harness serves `ClientApp/build` (not live source), so rebuild
+first or new layout won't appear. Run (from `ClientApp/`): `npm run build`
+Expected: PASS (`tsc -b && vite build`).
+
+- [ ] **Step 2: Run the integration tests**
+
+Run (from repo root): `dotnet test Application/Frigorino.IntegrationTests`
+Expected: PASS. Key scenarios that exercise the composer:
+- comment/quantity panel open via `composer-toggle-*` (icons still present inside the pill),
+- attach a photo via `composer-attach-button` on an empty field (attach is visible while empty — matches the new rule).
+
+If Docker/Testcontainers reports the daemon is unreachable, ask the user to start Docker Desktop rather than skipping.
+
+- [ ] **Step 3: Manual browser pass (the net for runtime/layout bugs)**
+
+Bring up the dev stack (`/dev-up`) and, in a list view, confirm visually:
+1. Empty field: pill shows the text input plus the comment + attach icons inside it; send button dimmed/disabled to the right.
+2. Start typing: the attach icon disappears, the comment icon stays, send lights up. Text field clearly has most of the width.
+3. Add a comment: comment icon turns its active colour, chip + panel still open from inside the pill.
+4. Edit an item: quantity + comment icons both visible inside the pill; warning-coloured border/send as today.
+5. No discard/trash button anywhere.
+
+- [ ] **Step 4: Tear down (if you brought the stack up)**
+
+Run `/dev-down` only if the user isn't keeping the stack up.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** pill layout (Task 1 Step 2), actions-hide-on-type via `!trimmed` (Task 1 Step 2), modifiers always render (Task 1 Step 2), send outside + dimmed-when-empty (`SendButton` unchanged, `disabled` on `!trimmed`), discard removed + `Delete` import removed (Task 1 Steps 1–2), dead i18n key removed (Task 2), testids preserved (`composer-toggle-*` kept, `composer-attach-button` unchanged, `autocomplete-input-*` unchanged), inline icon sizing (pill container override, Task 1 Step 2). All spec sections map to a task.
+- **No new feature-file edits:** icon sizing is overridden once from the pill rather than editing three feature files (DRY).
+- **Type consistency:** all identifiers referenced in the new markup (`actionFeatures`, `modifierFeatures`, `trimmed`, `completeAction`, `slotFor`, `preventInputBlur`, `ComposerTextField`, `SendButton`) already exist in `Composer.tsx` and are unchanged.

--- a/docs/superpowers/specs/2026-06-04-whatsapp-style-composer-design.md
+++ b/docs/superpowers/specs/2026-06-04-whatsapp-style-composer-design.md
@@ -1,0 +1,96 @@
+# WhatsApp-style Composer — Design
+
+**Date:** 2026-06-04
+**Component:** `ClientApp/src/components/composer/Composer.tsx`
+
+## Problem
+
+A client reported that the input composer gives too much horizontal space to its
+icon buttons and too little to the text field. Today the bottom row lays out
+`[discard] [modifier toggles] [action triggers] [textfield(flex:1)] [send]` as
+flat siblings, so on a narrow phone each 44px icon button steals width the text
+field needs. We want a WhatsApp-style layout where the text field dominates.
+
+## Goal
+
+The text field gets nearly the full width. Icon buttons live *inside* a rounded
+input pill; the round send button sits outside on the right.
+
+## Approach (Style A — icons inside the input pill)
+
+Restructure only the bottom flex row of `Composer.tsx`. The chip row, the
+modifier panels (Collapse), the edit header, `SendButton`, suggestions, and
+duplicate handling are all unchanged.
+
+New row structure:
+
+```
+[ pill:  ComposerTextField(flex:1)  ·  modifier toggles  ·  action triggers ] [ send ]
+```
+
+- **Pill** — a rounded `Box` with a subtle neutral fill (e.g. `action.hover` /
+  `grey.100`, theme-adaptive) and `borderRadius`. It contains the
+  `ComposerTextField` (`flex: 1`) followed by the inline modifier-toggle and
+  action-trigger icons. `flex: 1` on the pill so it fills the row beside the
+  send button.
+- **Outer `Paper`** — keeps its current elevation and edit/focus border
+  (`primary`/`warning` border colour, `&:hover, &:focus-within` highlight).
+  Padding stays so the pill has breathing room.
+- **Send button** — the existing `SendButton`, a separate round button to the
+  right of the pill (outside it), unchanged. When the field is empty it stays
+  visible but disabled (current behaviour), matching the mockup.
+- **Inline icon sizing** — the toggle/trigger icon buttons relax from
+  `minWidth/minHeight: 44` to ~36–38px so they read as in-field adornments. The
+  44px touch target is effectively preserved by the surrounding pill padding.
+
+## Visibility rule (general)
+
+Driven by feature `kind`, not per-feature hard-coding:
+
+- **Action** features (`kind: "action"`, e.g. attach) render **only when the
+  field is empty** (`!trimmed`). Attach creates a standalone media item, so it
+  is irrelevant once you start typing item text — and hiding it returns that
+  width to the text.
+- **Modifier** features (`kind: "modifier"`, e.g. comment, quantity) **always
+  render**. They augment the item being typed, so they stay available.
+
+Future features inherit this behaviour automatically from their `kind`.
+
+## Removed
+
+- The discard/trash `IconButton` (current `Composer.tsx` lines ~239–257) is
+  deleted entirely — confirmed unused, no test references it. Clearing typed
+  text is done by normal text selection/deletion.
+- The now-dead `common.discardInput` translation key in both
+  `public/locales/en/translation.json` and `public/locales/de/translation.json`.
+- The now-unused `Delete` icon import in `Composer.tsx`.
+
+## Unchanged
+
+- Comment/quantity **panels** (`Collapse`) and **chips** render above the row
+  exactly as today.
+- All testids: `composer-toggle-*`, `composer-panel-*`, `composer-chip-*`,
+  `composer-attach-button` (and its menu/file-input testids),
+  `autocomplete-input-textfield`.
+- `SendButton`, `EditHeader`, duplicate handling, suggestions, focus/blur
+  handling (`handleContainerClick`, `preventInputBlur`).
+
+## Test impact
+
+No tests expected to break:
+
+- No test references the discard button.
+- The attach integration test (`MediaItemSteps.WhenIAttachAPhoto`) clicks
+  `composer-attach-button` on an **empty** field, which matches the new
+  visibility rule (attach is present while the field is empty).
+
+A manual browser pass (dev-up + Playwright/manual) should confirm: pill spacing,
+the attach-hides-on-type transition, comment chip/panel still open from inside
+the pill, and edit mode (quantity + comment both visible).
+
+## Out of scope
+
+- No backend changes.
+- No change to the feature descriptor types (`ModifierFeature` / `ActionFeature`
+  in `types.ts`) — the visibility rule keys off the existing `kind` field.
+- No "+" expander, no collapsing-on-type for modifier icons (Style B/C rejected).


### PR DESCRIPTION
## Summary

Redesigns the list/inventory input composer toward a WhatsApp-style layout and themes the toasts to match the app.

**Composer**
- Text field now dominates the width: the field + icons live inside one rounded **pill**; the round send button sits outside. The old outer card is gone — the pill itself carries the focus/edit highlight border.
- **Action** features (attach) hide once you start typing; **modifier** features (comment, quantity) always stay. Driven by feature `kind`, so future features inherit the behavior.
- Removed the discard/trash button (and the dead `common.discardInput` i18n key).
- Tightened vertical padding in `ListFooter` / `InventoryFooter`.
- **Edit mode now autofocuses the field** (brings up the keyboard to edit immediately); skipped in add mode and when a chip opens a modifier panel.

**Mobile keyboard focus handling**
- One container-level `onMouseDown` (`keepKeyboardOpen`) keeps the soft keyboard open when tapping any composer control (buttons, chips), excluding real text inputs — replaces the inconsistent per-element handlers.
- Attach menu switched from a `Modal`-based `Menu` (which `aria-hide`s the page and collapses the keyboard) to a non-modal `Popper` + `MenuList` + `ClickAwayListener`.

**Toasts**
- Themed sonner via MUI `GlobalStyles` (theme tokens): dark surface, green action button, close button pulled inline to the right; added `closeButton` so toasts can be dismissed.

Spec + plan: `docs/superpowers/specs/2026-06-04-whatsapp-style-composer-design.md`, `docs/superpowers/plans/2026-06-04-whatsapp-style-composer.md`.

## Test Plan
- [x] `npm run tsc` / `npm run lint` / `npm run prettier` — clean
- [x] `npm run build` — SPA builds
- [x] `dotnet test Frigorino.IntegrationTests` — 116 passed, 0 failed (incl. attach-menu flow)
- [ ] Manual device check: pill focus border, attach hides on type, keyboard stays open on attach menu / control taps, edit-mode autofocus, themed toast + inline close