### PR TITLE
fix(pwa): push-only service worker to end stale-page updates

### DIFF
--- a/Application/Frigorino.Web/ClientApp/package-lock.json
+++ b/Application/Frigorino.Web/ClientApp/package-lock.json
@@ -50,9 +50,7 @@
                 "typescript-eslint": "^8.60.0",
                 "vite": "^8.0.14",
                 "vite-plugin-compression2": "^2.5.3",
-                "vite-plugin-pwa": "^1.3.0",
-                "workbox-core": "^7.4.1",
-                "workbox-precaching": "^7.4.1"
+                "vite-plugin-pwa": "^1.3.0"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/Application/Frigorino.Web/ClientApp/package.json
+++ b/Application/Frigorino.Web/ClientApp/package.json
@@ -66,8 +66,6 @@
         "typescript-eslint": "^8.60.0",
         "vite": "^8.0.14",
         "vite-plugin-compression2": "^2.5.3",
-        "vite-plugin-pwa": "^1.3.0",
-        "workbox-core": "^7.4.1",
-        "workbox-precaching": "^7.4.1"
+        "vite-plugin-pwa": "^1.3.0"
     }
 }

--- a/Application/Frigorino.Web/ClientApp/src/common/pwa.ts
+++ b/Application/Frigorino.Web/ClientApp/src/common/pwa.ts
@@ -1,0 +1,54 @@
+import { registerSW } from "virtual:pwa-register";
+
+// sessionStorage key + cooldown for the one-shot chunk-error reload (see below).
+const CHUNK_RELOAD_AT = "frigorino:chunk-reload-at";
+const CHUNK_RELOAD_COOLDOWN_MS = 10_000;
+
+// Wire up the service worker.
+//
+// The SW is push-only (see src/sw.ts) — it does not cache or serve the app, so a
+// normal page load already gets the latest deploy (index.html is `no-cache`,
+// hashed assets are immutable). There is therefore no version-reload coupling
+// here: registerType is "prompt" and we pass no refresh handler, so registration
+// only keeps Firebase background push alive and never reloads the page.
+export function initPwa(): void {
+    registerSW({ immediate: true });
+    installChunkErrorBackstop();
+}
+
+// Safety net for a deploy landing while a tab is open: an old, still-running
+// session can lazy-load a route chunk whose hashed filename the new deploy already
+// purged from the server → "Failed to fetch dynamically imported module" and a
+// broken screen. This can happen to any code-split SPA, service worker or not.
+// Reload once to pick up the fresh build. The timestamped cooldown lets a *later*
+// deploy in the same session recover too, while stopping a refresh loop if a
+// reload doesn't resolve it (e.g. a genuinely missing file).
+function installChunkErrorBackstop(): void {
+    const reloadOnce = () => {
+        const last = Number(sessionStorage.getItem(CHUNK_RELOAD_AT) ?? "0");
+        if (Date.now() - last < CHUNK_RELOAD_COOLDOWN_MS) {
+            return;
+        }
+        sessionStorage.setItem(CHUNK_RELOAD_AT, String(Date.now()));
+        window.location.reload();
+    };
+
+    const isChunkLoadError = (message: string) =>
+        /Failed to fetch dynamically imported module|Importing a module script failed|error loading dynamically imported module|ChunkLoadError/i.test(
+            message,
+        );
+
+    window.addEventListener("error", (event) => {
+        if (isChunkLoadError(event.message ?? "")) {
+            reloadOnce();
+        }
+    });
+    window.addEventListener("unhandledrejection", (event) => {
+        const reason = event.reason;
+        const message =
+            reason instanceof Error ? reason.message : String(reason ?? "");
+        if (isChunkLoadError(message)) {
+            reloadOnce();
+        }
+    });
+}

--- a/Application/Frigorino.Web/ClientApp/src/main.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/main.tsx
@@ -22,6 +22,11 @@ import { initForegroundPush } from "./common/pushNotifications";
 // push is unsupported or permission isn't granted.
 void initForegroundPush();
 
+import { initPwa } from "./common/pwa";
+
+// Register the push service worker and install the chunk-load-error reload net.
+initPwa();
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { StrictMode, Suspense } from "react";

--- a/Application/Frigorino.Web/ClientApp/src/sw.ts
+++ b/Application/Frigorino.Web/ClientApp/src/sw.ts
@@ -1,17 +1,35 @@
 /// <reference lib="webworker" />
-import { precacheAndRoute } from "workbox-precaching";
-import { clientsClaim } from "workbox-core";
 import { initializeApp } from "firebase/app";
 import { getMessaging, onBackgroundMessage } from "firebase/messaging/sw";
 
-declare const self: ServiceWorkerGlobalScope & {
-    __WB_MANIFEST: Array<{ url: string; revision: string | null }>;
-};
+declare const self: ServiceWorkerGlobalScope;
 
-// Precache the Vite build (injected at build time).
-precacheAndRoute(self.__WB_MANIFEST);
+// Push-only service worker. It deliberately does NOT precache or intercept any
+// app request — the SPA is always loaded fresh over HTTP (index.html is served
+// `no-cache`, hashed `/assets/*` are immutably cached by the browser), so there
+// is no stale-shell or purged-chunk failure mode to manage here. The sole job is
+// Firebase background push. `skipWaiting` lets an updated push handler activate
+// promptly; we don't `clientsClaim`, because there is no fetch handler to take
+// over and the page never depends on this worker for its content.
 self.skipWaiting();
-clientsClaim();
+
+// Migration cleanup: earlier versions of this worker precached the app shell with
+// Workbox. This push-only worker caches nothing, so on activate we purge those
+// now-orphaned precache caches — freeing storage and guaranteeing no stale shell
+// can ever be served to users upgrading from the precaching version.
+self.addEventListener("activate", (event) => {
+    event.waitUntil(
+        caches
+            .keys()
+            .then((keys) =>
+                Promise.all(
+                    keys
+                        .filter((key) => key.startsWith("workbox-precache"))
+                        .map((key) => caches.delete(key)),
+                ),
+            ),
+    );
+});
 
 // Firebase config mirrors src/common/auth.ts (public values).
 const firebaseApp = initializeApp({

--- a/Application/Frigorino.Web/ClientApp/vite.config.ts
+++ b/Application/Frigorino.Web/ClientApp/vite.config.ts
@@ -30,10 +30,16 @@ export default defineConfig(({ command }) => ({
             strategies: "injectManifest",
             srcDir: "src",
             filename: "sw.ts",
-            registerType: "autoUpdate",
+            // "prompt" (not "autoUpdate"): the SW is push-only and never serves the
+            // app shell, so there's no new app version to silently reload onto. We
+            // register it without a refresh handler (src/common/pwa.ts), so it never
+            // forces a reload.
+            registerType: "prompt",
             injectManifest: {
-                // Firebase messaging SW imports push the bundle over the default 2 MiB limit.
-                maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
+                // Push-only SW: no precaching. `injectionPoint: undefined` tells the
+                // plugin not to look for / inject a `self.__WB_MANIFEST`, so sw.ts
+                // needs no workbox precache machinery at all.
+                injectionPoint: undefined,
             },
             devOptions: {
                 enabled: true,

--- a/Application/Frigorino.Web/Program.cs
+++ b/Application/Frigorino.Web/Program.cs
@@ -245,12 +245,27 @@ var staticFileOptions = new StaticFileOptions
         if (IsIndexHtml(fileName))
         {
             ctx.Context.Response.Headers.CacheControl = "no-cache, must-revalidate";
+            return;
+        }
+
+        // The service worker script must always revalidate so a new push worker is
+        // picked up on the next visit. Browsers already bypass the HTTP cache for the
+        // SW script on update checks; this is belt-and-suspenders against any proxy
+        // or older client caching a stale sw.js and getting "stuck".
+        if (IsServiceWorker(fileName))
+        {
+            ctx.Context.Response.Headers.CacheControl = "no-cache, must-revalidate";
         }
 
         static bool IsIndexHtml(string name) =>
             name.Equals("index.html", StringComparison.OrdinalIgnoreCase)
             || name.Equals("index.html.br", StringComparison.OrdinalIgnoreCase)
             || name.Equals("index.html.gz", StringComparison.OrdinalIgnoreCase);
+
+        static bool IsServiceWorker(string name) =>
+            name.Equals("sw.js", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("sw.js.br", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("sw.js.gz", StringComparison.OrdinalIgnoreCase);
     },
 };
 


### PR DESCRIPTION
## Problem
Returning users were served the **previous** build on first load and only got the new one after a manual reload — and in the window between, an old session could `404` on a lazy-loaded chunk the deploy had purged, leaving a broken screen.

**Root cause:** the Workbox **precache** service worker (`skipWaiting` + `clientsClaim`) served the old cached app shell to returning users and swapped the controller mid-session, bypassing the (correct) `no-cache` header on `index.html`.

## Approach
The SW's only hard requirement is **Firebase background push**. Rather than harden the precache lifecycle, this drops precaching entirely — the riskier, staleness-prone machinery — and keeps the SW push-only.

- **`sw.ts`** — push-only worker: no `precacheAndRoute`, no navigation/fetch handling, no `clientsClaim`. Adds an `activate` cleanup that purges orphaned `workbox-precache` caches left by the previous version.
- **`vite.config.ts`** — `registerType: "prompt"` + `injectManifest.injectionPoint: undefined` (no precache manifest; SW needs no workbox deps).
- **`common/pwa.ts`** (new) — registers the SW (no refresh handler → never force-reloads) plus a one-shot, cooldown-guarded `ChunkLoadError` reload backstop (covers any code-split SPA, SW or not).
- **`Program.cs`** — `no-cache, must-revalidate` on `sw.js` so a new push worker is never cached stale.
- Removed now-unused `workbox-core` / `workbox-precaching` / `workbox-routing`.

The app shell is now always loaded fresh over HTTP (`index.html` `no-cache`, hashed assets `immutable`), so a reload always lands the latest deploy and the SW can no longer serve a stale app.

## Trade-offs
- **One-time transition cost:** a device's *currently installed* precache SW still controls its next visit, so that one visit may show old → the new worker activates + cleans up → fixed permanently thereafter.
- **Offline support dropped** — acceptable for a connected lists/inventory app.

## Verification
`tsc`, `lint`, `prettier --check`, `npm run build`, `dotnet build Frigorino.Web` all green. Build confirms **0 precache entries** (was 58) and a single bundled SW registration.

**Suggested stage check:** deploy this, then deploy any trivial follow-up, and confirm a returning tab lands on the latest build with no broken state.