### PR TITLE
UX polish: tinted action buttons, aligned feature screens, slimmer composer

### DIFF
--- a/Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/composer/Composer.tsx
@@ -1,4 +1,5 @@
-import { Box, Collapse } from "@mui/material";
+import { Close } from "@mui/icons-material";
+import { Box, Collapse, IconButton } from "@mui/material";
 import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ComposerTextField } from "./components/ComposerTextField";
@@ -173,6 +174,10 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
     const chipFeatures = modifierFeatures.filter(
         (feature) =>
             feature.renderChip &&
+            // While a modifier's panel is open its field already shows the value,
+            // so suppress the summary chip to avoid showing it twice. The chip
+            // returns as the summary once the panel closes.
+            openId !== feature.id &&
             !isModifierValueEmpty(feature, values[feature.id]),
     );
 
@@ -197,9 +202,7 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
                 cursor: "text",
             }}
         >
-            {isEditing && editing && (
-                <EditHeader label={editing.label} onCancel={handleCancelEdit} />
-            )}
+            {isEditing && editing && <EditHeader label={editing.label} />}
 
             {chipFeatures.length > 0 && (
                 <Box
@@ -311,6 +314,21 @@ export function Composer<const F extends readonly AnyFeature[] = []>({
                             </Box>
                         ))}
                 </Box>
+
+                {isEditing && (
+                    <IconButton
+                        onClick={handleCancelEdit}
+                        aria-label={t("common.cancel")}
+                        sx={{
+                            minWidth: 44,
+                            minHeight: 44,
+                            color: "text.secondary",
+                            "&:hover": { bgcolor: "action.hover" },
+                        }}
+                    >
+                        <Close />
+                    </IconButton>
+                )}
 
                 <SendButton
                     onClick={completeText}

--- a/Application/Frigorino.Web/ClientApp/src/components/composer/components/EditHeader.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/composer/components/EditHeader.tsx
@@ -1,44 +1,32 @@
-import { Close, Edit } from "@mui/icons-material";
-import { Box, IconButton, Typography } from "@mui/material";
+import { Edit } from "@mui/icons-material";
+import { Box, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 interface EditHeaderProps {
     label?: string;
-    onCancel: () => void;
 }
 
-export const EditHeader = ({ label, onCancel }: EditHeaderProps) => {
+// Slim left-aligned edit cue. Cancel lives in the input row (on the send-button
+// axis), so this is label-only — a compact marker, not a full-width bar.
+export const EditHeader = ({ label }: EditHeaderProps) => {
     const { t } = useTranslation();
     return (
         <Box
             sx={{
-                display: "flex",
+                display: "inline-flex",
                 alignItems: "center",
-                justifyContent: "space-between",
-                px: 0.5,
+                gap: 0.5,
+                px: 0.75,
                 py: 0.25,
+                mb: 0.5,
                 bgcolor: "warning.50",
                 borderRadius: 1,
-                mb: 0.5,
             }}
         >
-            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                <Edit fontSize="small" color="warning" />
-                <Typography variant="caption" sx={{ color: "warning.dark" }}>
-                    {label ?? t("common.edit")}
-                </Typography>
-            </Box>
-            <IconButton
-                size="small"
-                onClick={onCancel}
-                aria-label={t("common.cancel")}
-                sx={{
-                    color: "warning.dark",
-                    "&:hover": { bgcolor: "warning.100" },
-                }}
-            >
-                <Close fontSize="small" />
-            </IconButton>
+            <Edit sx={{ fontSize: 14 }} color="warning" />
+            <Typography variant="caption" sx={{ color: "warning.dark" }}>
+                {label ?? t("common.edit")}
+            </Typography>
         </Box>
     );
 };

--- a/Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/dashboard/WelcomePage.tsx
@@ -1,4 +1,4 @@
-import { Add, ChevronRight } from "@mui/icons-material";
+import { Add, ChevronRight, ExpandMore } from "@mui/icons-material";
 import {
     Box,
     Card,
@@ -29,7 +29,7 @@ import {
     getExpiryColor,
     getExpiryInfo,
 } from "../../utils/dateUtils";
-import { sectionColors } from "../../theme";
+import { sectionColors, tintedActionButtonSx } from "../../theme";
 import { sectionIcons } from "../../common/sections";
 
 export const WelcomePage = () => {
@@ -281,10 +281,21 @@ export const WelcomePage = () => {
 
             <Stack spacing={{ xs: 1.5, sm: 2 }} sx={{ mb: { xs: 3, sm: 4 } }}>
                 {collections.map((collection) => {
+                    // Only lists and inventory have expandable item previews;
+                    // recipes is a placeholder card with nothing to reveal.
+                    const isExpandable =
+                        collection.id === "einkaufslisten" ||
+                        collection.id === "inventar";
                     const isExpanded =
                         expandedSections.includes(collection.id) &&
-                        (collection.id === "einkaufslisten" ||
-                            collection.id === "inventar");
+                        isExpandable;
+                    // Tinted, section-colored action buttons so they read as
+                    // clearly tappable controls rather than ghost icons.
+                    const actionButtonSx = {
+                        ...tintedActionButtonSx(collection.color),
+                        width: 34,
+                        height: 34,
+                    };
                     return (
                         <Card
                             key={collection.id}
@@ -330,7 +341,13 @@ export const WelcomePage = () => {
                                         >
                                             {collection.icon}
                                         </Box>
-                                        <Box>
+                                        <Box
+                                            sx={{
+                                                display: "flex",
+                                                alignItems: "center",
+                                                gap: 0.5,
+                                            }}
+                                        >
                                             <Typography
                                                 variant="body1"
                                                 sx={{
@@ -340,6 +357,19 @@ export const WelcomePage = () => {
                                             >
                                                 {collection.label}
                                             </Typography>
+                                            {isExpandable && (
+                                                <ExpandMore
+                                                    fontSize="small"
+                                                    sx={{
+                                                        color: "text.secondary",
+                                                        transition:
+                                                            "transform 0.2s ease",
+                                                        transform: isExpanded
+                                                            ? "rotate(180deg)"
+                                                            : "none",
+                                                    }}
+                                                />
+                                            )}
                                         </Box>
                                     </Box>
 
@@ -356,14 +386,7 @@ export const WelcomePage = () => {
                                                 e.stopPropagation();
                                                 handleAddItem(collection.id);
                                             }}
-                                            sx={{
-                                                color: "text.secondary",
-                                                width: 32,
-                                                height: 32,
-                                                "&:hover": {
-                                                    bgcolor: "action.hover",
-                                                },
-                                            }}
+                                            sx={actionButtonSx}
                                         >
                                             <Add fontSize="small" />
                                         </IconButton>
@@ -384,16 +407,9 @@ export const WelcomePage = () => {
                                                     });
                                                 }
                                             }}
-                                            sx={{
-                                                color: "text.secondary",
-                                                width: 32,
-                                                height: 32,
-                                                "&:hover": {
-                                                    bgcolor: "action.hover",
-                                                },
-                                            }}
+                                            sx={actionButtonSx}
                                         >
-                                            <ChevronRight />
+                                            <ChevronRight fontSize="small" />
                                         </IconButton>
                                     </Box>
                                 </Box>

--- a/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
@@ -159,7 +159,9 @@ export const PageHeadActionBar = memo(
                                 <IconButton
                                     onClick={handleMenuOpen}
                                     data-testid={menuButtonTestId}
-                                    sx={tintedActionButtonSx(neutralActionColor)}
+                                    sx={tintedActionButtonSx(
+                                        neutralActionColor,
+                                    )}
                                 >
                                     <MoreVert />
                                 </IconButton>

--- a/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
@@ -13,7 +13,13 @@ import {
 import { useRouter } from "@tanstack/react-router";
 import { memo, useCallback, useState } from "react";
 import { sectionIcons } from "../../common/sections";
-import { sectionColors, type SectionKey } from "../../theme";
+import {
+    featureContentPx,
+    neutralActionColor,
+    sectionColors,
+    tintedActionButtonSx,
+    type SectionKey,
+} from "../../theme";
 
 export type HeadNavigationAction = {
     text?: string;
@@ -52,6 +58,10 @@ export const PageHeadActionBar = memo(
         const router = useRouter();
         const SectionIcon = section ? sectionIcons[section] : null;
         const sectionColor = section ? sectionColors[section] : undefined;
+        // The primary direct action (edit) takes the page's section color so it
+        // matches the identity glyph; falls back to the brand green when a page
+        // hasn't declared a section.
+        const identityColor = sectionColor ?? "#43A047";
         const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(
             null,
         );
@@ -83,7 +93,7 @@ export const PageHeadActionBar = memo(
             <>
                 <Container
                     maxWidth={maxWidth}
-                    sx={{ px: 1.5, py: 1.5, flexShrink: 0 }}
+                    sx={{ px: featureContentPx, py: 1.5, flexShrink: 0 }}
                 >
                     <Box
                         sx={{
@@ -136,20 +146,11 @@ export const PageHeadActionBar = memo(
                                     key={index}
                                     onClick={action.onClick}
                                     data-testid={action.testId}
-                                    sx={{
-                                        bgcolor:
-                                            index === 0
-                                                ? "primary.main"
-                                                : "grey.100",
-                                        color:
-                                            index === 0 ? "white" : "grey.700",
-                                        "&:hover": {
-                                            bgcolor:
-                                                index === 0
-                                                    ? "primary.dark"
-                                                    : "grey.200",
-                                        },
-                                    }}
+                                    sx={tintedActionButtonSx(
+                                        index === 0
+                                            ? identityColor
+                                            : neutralActionColor,
+                                    )}
                                 >
                                     {action.icon}
                                 </IconButton>
@@ -158,11 +159,7 @@ export const PageHeadActionBar = memo(
                                 <IconButton
                                     onClick={handleMenuOpen}
                                     data-testid={menuButtonTestId}
-                                    sx={{
-                                        bgcolor: "grey.100",
-                                        color: "grey.700",
-                                        "&:hover": { bgcolor: "grey.200" },
-                                    }}
+                                    sx={tintedActionButtonSx(neutralActionColor)}
                                 >
                                     <MoreVert />
                                 </IconButton>

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/items/components/InventoryContainer.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/items/components/InventoryContainer.tsx
@@ -1,5 +1,6 @@
 import { Container } from "@mui/material";
 import { forwardRef } from "react";
+import { featureContentPx } from "../../../../theme";
 import { SortableList } from "../../../../components/sortables/SortableList";
 import type { InventoryItemResponse } from "../../../../lib/api";
 import { useDeleteInventoryItem } from "../useDeleteInventoryItem";
@@ -40,7 +41,7 @@ export const InventoryContainer = forwardRef<
                 sx={{
                     flex: 1,
                     overflow: "auto",
-                    px: 3,
+                    px: featureContentPx,
                     py: 0,
                     minHeight: 0,
                 }}

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/items/components/InventoryFooter.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/items/components/InventoryFooter.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../../../components/composer";
 import { useItemComposer } from "../../../../hooks/useItemComposer";
 import type { InventoryItemResponse, QuantityDto } from "../../../../lib/api";
+import { featureContentPx } from "../../../../theme";
 
 const features = [quantityComposerFeature, expiryFeature] as const;
 
@@ -115,7 +116,7 @@ export const InventoryFooter = memo(
                 maxWidth="sm"
                 sx={{
                     flexShrink: 0,
-                    px: 3,
+                    px: featureContentPx,
                     py: 1,
                     borderTop: 1,
                     borderColor: "divider",

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListContainer.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListContainer.tsx
@@ -1,5 +1,6 @@
 import { Container } from "@mui/material";
 import { forwardRef } from "react";
+import { featureContentPx } from "../../../../theme";
 import { SortableList } from "../../../../components/sortables/SortableList";
 import type { ListItemResponse } from "../../../../lib/api";
 import { useDeleteListItem } from "../useDeleteListItem";
@@ -53,7 +54,7 @@ export const ListContainer = forwardRef<HTMLDivElement, ListContainerProps>(
                 sx={{
                     flex: 1,
                     overflow: "auto",
-                    px: 3,
+                    px: featureContentPx,
                     py: 0,
                     minHeight: 0,
                 }}

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListFooter.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/items/components/ListFooter.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../../../components/composer";
 import { useItemComposer } from "../../../../hooks/useItemComposer";
 import type { ListItemResponse, QuantityDto } from "../../../../lib/api";
+import { featureContentPx } from "../../../../theme";
 
 // Lists add via free-text (extraction fills the quantity), so the add composer stays
 // quantity-free — but a comment can be attached at add time. Manual quantity entry/correction
@@ -169,7 +170,7 @@ export const ListFooter = memo(
                 maxWidth="sm"
                 sx={{
                     flexShrink: 0,
-                    px: 3,
+                    px: featureContentPx,
                     py: 1,
                     borderTop: 1,
                     borderColor: "divider",

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/promote/PromoteBar.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/promote/PromoteBar.tsx
@@ -3,6 +3,7 @@ import { Button, Paper, Typography } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { featureContentPx } from "../../../theme";
 import { useList } from "../useList";
 import { PromoteReviewSheet } from "./PromoteReviewSheet";
 
@@ -36,14 +37,14 @@ export const PromoteBar = ({ householdId, listId }: PromoteBarProps) => {
                 data-testid="promote-bar"
                 data-count={count}
                 sx={{
-                    mx: 3,
+                    mx: featureContentPx,
                     mb: 1,
                     px: 1.5,
                     py: 1,
                     display: "flex",
                     alignItems: "center",
                     gap: 1,
-                    bgcolor: (theme) => alpha(theme.palette.primary.main, 0.15),
+                    bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
                     color: "text.primary",
                     border: "1px solid",
                     borderColor: (theme) =>
@@ -62,9 +63,13 @@ export const PromoteBar = ({ householdId, listId }: PromoteBarProps) => {
                 <Button
                     size="small"
                     variant="contained"
-                    color="primary"
                     data-testid="promote-bar-review"
                     onClick={() => setOpen(true)}
+                    sx={{
+                        bgcolor: (theme) =>
+                            alpha(theme.palette.primary.main, 0.85),
+                        "&:hover": { bgcolor: "primary.main" },
+                    }}
                 >
                     {t("promote.review")}
                 </Button>

--- a/Application/Frigorino.Web/ClientApp/src/theme.ts
+++ b/Application/Frigorino.Web/ClientApp/src/theme.ts
@@ -1,4 +1,4 @@
-import { createTheme, responsiveFontSizes } from "@mui/material/styles";
+import { alpha, createTheme, responsiveFontSizes } from "@mui/material/styles";
 
 export const appTheme = responsiveFontSizes(
     createTheme({
@@ -33,7 +33,35 @@ export const sectionColors = {
 
 export type SectionKey = keyof typeof sectionColors;
 
+// Neutral grey for non-identity action buttons (e.g. the overflow menu) — visible
+// on the dark surface without competing with the section-colored identity actions.
+export const neutralActionColor = "#9E9E9E";
+
+// Soft, tinted, bordered action button. Reads as clearly tappable while staying
+// quiet — a filled-but-muted glyph instead of a ghost icon. Pass a section color
+// for identity actions (add / open / edit) or neutralActionColor for secondary
+// ones. Shared by the dashboard cards and feature headers so action buttons look
+// the same everywhere.
+export const tintedActionButtonSx = (color: string) => ({
+    color,
+    bgcolor: alpha(color, 0.14),
+    border: `1px solid ${alpha(color, 0.35)}`,
+    transition: "all 0.2s ease",
+    "&:hover": {
+        bgcolor: alpha(color, 0.24),
+        borderColor: color,
+    },
+    "&:active": {
+        bgcolor: alpha(color, 0.32),
+    },
+});
+
 export const pageContainerSx = {
     py: { xs: 2, sm: 3 },
     px: { xs: 1, sm: 2 },
 };
+
+// Shared horizontal inset for the feature screens (list/inventory header, item
+// list, composer footer, promote bar) so their left/right edges line up. One
+// source of truth keeps them from drifting apart.
+export const featureContentPx = 3;


### PR DESCRIPTION
Small UX adjustments across the dashboard and list/inventory feature screens, driven by user feedback (action buttons unclear, inconsistent alignment, composer vertical clutter).

## Changes

### Action buttons — clearly tappable + section-colored
- New shared `tintedActionButtonSx(color)` helper in `theme.ts` (soft tinted fill + border + hover/active states).
- **Dashboard** `+` / `>` buttons now use the section color (blue/teal/coral) instead of muted ghost icons.
- **Feature headers** (`PageHeadActionBar`): edit button takes the page's section color (instead of solid primary); menu/neutral buttons use a neutral grey tint.

### Promote bar — toned down
- "Überprüfen" button uses an alpha'd primary green instead of fully solid; goes solid on hover.

### Horizontal alignment
- Shared `featureContentPx` inset routed through the list/inventory header, item list, footer, and promote bar — the header was the odd one out (12px vs 24px). Now everything lines up and can't drift.

### Composer — less vertical clutter
- Hide a modifier's summary chip while its panel is open (no more showing e.g. the `11.06.` chip **and** the date field at once).
- Move the edit-mode cancel ✕ into the input row, onto the send-button axis (`[ pill ][ ✕ ][ ➤ ]`).
- Slim `EditHeader` from a full-width bar to a compact left-aligned `✏️ Bearbeiten` label.

### Dashboard expandability cue
- Rotating expand chevron next to the title on the expandable list/inventory cards (not on the Recipes placeholder).

## Verification
- `npm run tsc` ✅
- `npm run lint` ✅
- Manual smoke test by the user: alignment confirmed solid; dashboard chevron + buttons look good.