### PR TITLE
fix(statusline): cache git branch off the hot render path

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -2,7 +2,7 @@
 # Claude Code status line: dir | branch | model | ctx% | 5h% | 7d%
 input=$(cat)
 printf '%s' "$input" | python -c "
-import sys, json, os, subprocess, datetime
+import sys, json, os, subprocess, datetime, time, tempfile, hashlib
 
 d = json.load(sys.stdin)
 
@@ -30,20 +30,63 @@ cwd = (d.get('workspace') or {}).get('current_dir') or d.get('cwd') or ''
 model = (d.get('model') or {}).get('display_name', '')
 dir_name = os.path.basename(cwd.rstrip('/\\\\')) if cwd else ''
 
+# Branch is the only expensive part (git subprocess). Cache it per-cwd with a
+# short TTL so rapid re-renders during heavy work skip git entirely, and a slow
+# or locked git can never blank the bar — we fall back to the last cached value.
+BRANCH_TTL = 10  # seconds
+
+def read_cache(path):
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return f.read().strip()
+    except Exception:
+        return None
+
+def to_native(p):
+    # MSYS '/c/foo' -> 'C:/foo' so native git.exe (no MSYS path mangling) can parse it
+    if len(p) >= 3 and p[0] == '/' and p[2] == '/' and p[1].isalpha():
+        return p[1].upper() + ':/' + p[3:]
+    return p
+
+def git_branch(cwd):
+    cwd = to_native(cwd)
+    try:
+        r = subprocess.run(['git', '-C', cwd, 'rev-parse', '--abbrev-ref', 'HEAD'],
+                           capture_output=True, text=True, timeout=0.5)
+        if r.returncode != 0:
+            return None
+        name = r.stdout.strip()
+        if name != 'HEAD':
+            return name
+        r = subprocess.run(['git', '-C', cwd, 'rev-parse', '--short', 'HEAD'],
+                           capture_output=True, text=True, timeout=0.5)
+        return r.stdout.strip() if r.returncode == 0 else None
+    except Exception:
+        return None
+
 branch = ''
 if cwd:
+    key = hashlib.md5(cwd.encode('utf-8')).hexdigest()
+    cache_path = os.path.join(tempfile.gettempdir(), 'cc-statusline-branch-' + key)
+    fresh = False
     try:
-        r = subprocess.run(['git', '-C', cwd, 'symbolic-ref', '--short', 'HEAD'],
-                           capture_output=True, text=True, timeout=2)
-        if r.returncode == 0:
-            branch = r.stdout.strip()
+        fresh = (time.time() - os.path.getmtime(cache_path)) < BRANCH_TTL
+    except OSError:
+        fresh = False
+    if fresh:
+        branch = read_cache(cache_path) or ''
+    else:
+        name = git_branch(cwd)
+        if name is not None:
+            branch = name
+            try:
+                with open(cache_path, 'w', encoding='utf-8') as f:
+                    f.write(name)
+            except Exception:
+                pass
         else:
-            r = subprocess.run(['git', '-C', cwd, 'rev-parse', '--short', 'HEAD'],
-                               capture_output=True, text=True, timeout=2)
-            if r.returncode == 0:
-                branch = r.stdout.strip()
-    except Exception:
-        pass
+            # git failed/timed out — reuse stale cache rather than dropping branch
+            branch = read_cache(cache_path) or ''
 
 ctx = d.get('context_window') or {}
 ctx_pct = ctx.get('used_percentage')
@@ -97,5 +140,8 @@ seven_part = fmt_pct('7d', seven_d)
 if seven_part:
     parts.append(seven_part)
 
-sys.stdout.write(' | '.join(parts))
+out = ' | '.join(parts)
+if not out:
+    out = dir_name or model or 'claude'
+sys.stdout.write(out)
 "


### PR DESCRIPTION
## Why

The statusline disappeared intermittently during heavy/parallel work (observed across multiple sessions). Root cause: the script spawned `bash → python → up to 2 git subprocesses` (each `timeout 2s`) on **every** render. Claude Code debounces statusline updates at 300ms and **cancels the in-flight run** when a new update fires — so a slow render never completes and the bar goes blank until work settles. More parallel work (subagents, builds, auto mode) = more frequent cancellation. Confirmed against the [statusLine docs](https://code.claude.com/docs/en/statusline); not a payload/contract mismatch (`context_window` + `rate_limits` fields are correct).

## What

- **Git off the hot path** — branch cached per-cwd in temp with a 10s TTL; rapid re-renders skip git entirely.
- **Bounded worst case** — two git calls collapsed to one (`rev-parse --abbrev-ref HEAD`, short-hash fallback only for detached HEAD); `timeout 2s → 0.5s`.
- **Never blank** — slow/locked git reuses the last cached branch; final output falls back to dir/model/`claude` so it can never emit 0 bytes.
- **Path robustness** — normalizes MSYS `/c/...` → `C:/...` so native `git.exe` resolves the cwd regardless of form.

Existing layout is unchanged (`dir | branch | model | ctx% | 5h% | 7d%`).

## Verification

- Realistic `C:/` payload renders the full line incl. branch + ctx + 5h/7d ✅
- Cache file written and reused on subsequent renders (no git spawn on hits) ✅
- `{}` empty input → `claude` (non-empty), never blank ✅
- Both `C:/` and `/c/` cwd forms resolve the branch ✅
- No Python syntax warnings ✅

Tooling-only change (`.claude/statusline-command.sh`); no app code touched.