### PR TITLE
feat: delete inventory item from calendar with confirm + undo

### DIFF
--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/calendar/components/CalendarItemActionBar.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/calendar/components/CalendarItemActionBar.tsx
@@ -1,5 +1,13 @@
-import { Edit } from "@mui/icons-material";
-import { Box, Button, Paper, Slide, Stack, Typography } from "@mui/material";
+import { Delete, Edit } from "@mui/icons-material";
+import {
+    Box,
+    Button,
+    IconButton,
+    Paper,
+    Slide,
+    Stack,
+    Typography,
+} from "@mui/material";
 import { useTranslation } from "react-i18next";
 import {
     Composer,
@@ -23,6 +31,7 @@ interface CalendarItemActionBarProps {
     item: ExpiryCalendarItemResponse | null;
     editing: boolean;
     onEdit: () => void;
+    onDelete: () => void;
     onCancelEdit: () => void;
     onSave: (
         text: string,
@@ -39,6 +48,7 @@ export const CalendarItemActionBar = ({
     item,
     editing,
     onEdit,
+    onDelete,
     onCancelEdit,
     onSave,
     isSaving,
@@ -117,6 +127,15 @@ export const CalendarItemActionBar = ({
                                 {metaLine}
                             </Typography>
                         </Box>
+                        <IconButton
+                            size="small"
+                            color="error"
+                            onClick={onDelete}
+                            aria-label={t("common.delete")}
+                            data-testid="calendar-action-bar-delete"
+                        >
+                            <Delete />
+                        </IconButton>
                         <Button
                             variant="contained"
                             size="small"

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/calendar/pages/ExpiryCalendarPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/calendar/pages/ExpiryCalendarPage.tsx
@@ -34,6 +34,7 @@ import { calendarLevelColor } from "../calendarColors";
 import { useQueryClient } from "@tanstack/react-query";
 import { getExpiryCalendarQueryKey } from "../../../../lib/api/@tanstack/react-query.gen";
 import type { QuantityDto } from "../../../../lib/api";
+import { useDeleteInventoryItem } from "../../items/useDeleteInventoryItem";
 import { useUpdateInventoryItem } from "../../items/useUpdateInventoryItem";
 import { CalendarItemActionBar } from "../components/CalendarItemActionBar";
 import { CalendarLevelToggles } from "../components/CalendarLevelToggles";
@@ -75,6 +76,7 @@ export const ExpiryCalendarPage = () => {
 
     const queryClient = useQueryClient();
     const updateMutation = useUpdateInventoryItem();
+    const deleteMutation = useDeleteInventoryItem();
 
     // The full selected item (incl. quantity, which isn't in the FullCalendar event props).
     const selectedItem = items?.find((item) => item.id === selectedId) ?? null;
@@ -229,6 +231,24 @@ export const ExpiryCalendarPage = () => {
         setEditing(false);
     };
 
+    // Delete the selected item. The shared hook surfaces the undo toast and keeps both the
+    // inventory-items and expiry-calendar queries in sync. Drop the selection immediately so
+    // the action bar slides out without waiting for the calendar refetch.
+    const handleDelete = () => {
+        if (!selectedItem) {
+            return;
+        }
+        deleteMutation.mutate({
+            path: {
+                householdId,
+                inventoryId: selectedItem.inventoryId,
+                itemId: selectedItem.id,
+            },
+        });
+        setEditing(false);
+        setSelectedId(null);
+    };
+
     const handleEventClick = (info: EventClickArg) => {
         // Stop the wrapper's clear-on-empty handler from firing for this same click.
         info.jsEvent.stopPropagation();
@@ -380,6 +400,7 @@ export const ExpiryCalendarPage = () => {
                 item={selectedItem}
                 editing={editing}
                 onEdit={() => setEditing(true)}
+                onDelete={handleDelete}
                 onCancelEdit={() => setEditing(false)}
                 onSave={handleSave}
                 isSaving={updateMutation.isPending}

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/calendar/pages/ExpiryCalendarPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/calendar/pages/ExpiryCalendarPage.tsx
@@ -14,6 +14,7 @@ import {
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { ConfirmDialog } from "../../../../components/dialogs/ConfirmDialog";
 import { PageHeadActionBar } from "../../../../components/shared/PageHeadActionBar";
 import { SearchInputRow } from "../../../../components/shared/SearchInputRow";
 import { useCurrentHousehold } from "../../../me/activeHousehold/useCurrentHousehold";
@@ -73,6 +74,9 @@ export const ExpiryCalendarPage = () => {
 
     // Edit mode for the selected item. Selection (selectedId) can be active without editing.
     const [editing, setEditing] = useState(false);
+
+    // Delete confirmation for the selected item.
+    const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
     const queryClient = useQueryClient();
     const updateMutation = useUpdateInventoryItem();
@@ -231,10 +235,10 @@ export const ExpiryCalendarPage = () => {
         setEditing(false);
     };
 
-    // Delete the selected item. The shared hook surfaces the undo toast and keeps both the
-    // inventory-items and expiry-calendar queries in sync. Drop the selection immediately so
-    // the action bar slides out without waiting for the calendar refetch.
-    const handleDelete = () => {
+    // Delete the selected item once confirmed. The shared hook surfaces the undo toast and keeps
+    // both the inventory-items and expiry-calendar queries in sync. Drop the selection immediately
+    // so the action bar slides out without waiting for the calendar refetch.
+    const handleConfirmDelete = () => {
         if (!selectedItem) {
             return;
         }
@@ -245,6 +249,7 @@ export const ExpiryCalendarPage = () => {
                 itemId: selectedItem.id,
             },
         });
+        setConfirmDeleteOpen(false);
         setEditing(false);
         setSelectedId(null);
     };
@@ -400,10 +405,28 @@ export const ExpiryCalendarPage = () => {
                 item={selectedItem}
                 editing={editing}
                 onEdit={() => setEditing(true)}
-                onDelete={handleDelete}
+                onDelete={() => setConfirmDeleteOpen(true)}
                 onCancelEdit={() => setEditing(false)}
                 onSave={handleSave}
                 isSaving={updateMutation.isPending}
+            />
+            <ConfirmDialog
+                open={confirmDeleteOpen && selectedItem !== null}
+                onClose={() => setConfirmDeleteOpen(false)}
+                onConfirm={handleConfirmDelete}
+                title={t("common.delete")}
+                description={
+                    <>
+                        {t("common.confirmDelete")} "{selectedItem?.text}"?
+                    </>
+                }
+                confirmLabel={t("common.delete")}
+                confirmLabelPending={t("common.deleting")}
+                cancelLabel={t("common.cancel")}
+                isPending={deleteMutation.isPending}
+                confirmTestId="calendar-delete-confirm"
+                cancelTestId="calendar-delete-cancel"
+                maxWidth="xs"
             />
         </>
     );

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/items/useDeleteInventoryItem.ts
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/items/useDeleteInventoryItem.ts
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { useDebouncedInvalidation } from "../../../hooks/useDebouncedInvalidation";
 import {
     deleteInventoryItemMutation,
+    getExpiryCalendarQueryKey,
     getInventoryItemsQueryKey,
 } from "../../../lib/api/@tanstack/react-query.gen";
 import type { InventoryItemResponse } from "../../../lib/api/types.gen";
@@ -73,6 +74,14 @@ export const useDeleteInventoryItem = () => {
                         householdId: variables.path.householdId,
                         inventoryId: variables.path.inventoryId,
                     },
+                }),
+            );
+            // The expiry calendar reads a separate query; keep it in sync so a delete
+            // (and its undo, which is triggered from inside this hook's toast) is
+            // reflected on the calendar view too.
+            debouncedInvalidate(
+                getExpiryCalendarQueryKey({
+                    path: { householdId: variables.path.householdId },
                 }),
             );
         },

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/items/useRestoreInventoryItem.ts
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/items/useRestoreInventoryItem.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
+    getExpiryCalendarQueryKey,
     getInventoryItemsQueryKey,
     restoreInventoryItemMutation,
 } from "../../../lib/api/@tanstack/react-query.gen";
@@ -16,6 +17,13 @@ export const useRestoreInventoryItem = () => {
                         householdId: variables.path.householdId,
                         inventoryId: variables.path.inventoryId,
                     },
+                }),
+            });
+            // Keep the expiry calendar (a separate query) in sync when an item is
+            // restored via the undo toast.
+            queryClient.invalidateQueries({
+                queryKey: getExpiryCalendarQueryKey({
+                    path: { householdId: variables.path.householdId },
                 }),
             });
         },

--- a/BUGS.md
+++ b/BUGS.md
@@ -13,3 +13,15 @@ focused. Likely fix if confirmed: surface foreground messages as an in-app toast
 `showNotification` for the background path.
 
 Deferred from the expiry-notifications feature work (testing feedback item #4).
+
+## Inventory fails to load when opening a notification for a non-active household
+
+With multiple households: if you receive an expiry notification for Household B
+while Household A is the active household, tapping the notification opens the app
+to the deep-link target (an inventory in Household B), but the inventory does not
+load. The active household is still A (kept in the HTTP session + persisted to
+`User.LastActiveHouseholdId`), so the household-scoped request is mismatched
+against the link's Household B target. Likely fix: the notification deep-link
+should carry the target household id and switch the active household to it on
+open (or the inventory route should detect the mismatch and switch) before
+issuing the scoped query.


### PR DESCRIPTION
## Summary
Adds a delete affordance to the inventory **expiry calendar** detail view (the bottom action bar), left of the Edit button.

- Red delete **IconButton** left of Edit in `CalendarItemActionBar`.
- Tapping it opens a **confirmation modal** (shared `ConfirmDialog`) showing the item name.
- On confirm, the item is deleted via the existing `useDeleteInventoryItem` hook, which surfaces the **undo toast** (sonner) as a safety net — identical to list/inventory item deletes.
- Delete and its undo now also invalidate the **expiry-calendar query** (a separate active query), so the calendar view updates immediately on both delete and restore. The restore-path invalidation lives in the hooks because undo is triggered from inside the delete toast.

## Flow
Tap Delete → confirm modal → Confirm → item deleted + undo toast → action bar slides out. Undo restores the item to the calendar.

## i18n
Reuses existing keys (`common.confirmDelete`, `common.delete`, `common.deleting`, `common.cancel`, `common.itemDeleted`, `common.undo`) — no new translations.

## Verification
- `npm run tsc` ✅
- `npm run lint` ✅
- `npm run prettier` ✅

Not yet verified in a running browser.