### PR TITLE
fix: always render quantity input in promote sheet

### DIFF
--- a/Application/Frigorino.IntegrationTests/Slices/Lists/Promote.feature
+++ b/Application/Frigorino.IntegrationTests/Slices/Lists/Promote.feature
@@ -50,6 +50,29 @@ Feature: Promote checked items to inventory (SPA)
     Then the promote bar shows 1 item
     And the promote sheet is not visible
 
+  Scenario: A row whose source had no quantity still accepts one, and it lands in inventory
+    Given there is a list named "Weekly Groceries" with item "Milk"
+    And there is an inventory named "Fridge"
+    And the product "milk" is in the catalog
+    When I open the list "Weekly Groceries"
+    And I toggle "Milk" as done
+    And I open the promote review sheet
+    Then the promote row "Milk" shows a quantity input
+    When I enter quantity "5" for "Milk" in the promote sheet
+    And I add the selected promote items
+    And I open the inventory "Fridge"
+    Then the inventory item "Milk" shows quantity "5"
+
+  Scenario: An invalid quantity blocks adding
+    Given there is a list named "Weekly Groceries" with item "Milk"
+    And there is an inventory named "Fridge"
+    And the product "milk" is in the catalog
+    When I open the list "Weekly Groceries"
+    And I toggle "Milk" as done
+    And I open the promote review sheet
+    And I enter quantity "abc" for "Milk" in the promote sheet
+    Then the promote add button is disabled
+
   Scenario: A selected row with no expiry date blocks adding
     Given there is a list named "Weekly Groceries" with item "Milk"
     And there is an inventory named "Fridge"

--- a/Application/Frigorino.IntegrationTests/Slices/Lists/PromoteSteps.cs
+++ b/Application/Frigorino.IntegrationTests/Slices/Lists/PromoteSteps.cs
@@ -80,6 +80,23 @@ public class PromoteSteps(ScenarioContextHolder ctx, TestApiClient api)
             .Not.ToBeVisibleAsync();
     }
 
+    [Then("the promote row {string} shows a quantity input")]
+    public async Task ThenThePromoteRowShowsAQuantityInput(string itemText)
+    {
+        // Regression guard: the input must render even when the source list item had no
+        // quantity — otherwise you can't record what you actually bought.
+        await Assertions.Expect(ctx.Page.GetByTestId($"promote-row-quantity-value-{itemText}"))
+            .ToBeVisibleAsync();
+    }
+
+    [When("I enter quantity {string} for {string} in the promote sheet")]
+    public async Task WhenIEnterQuantityForInThePromoteSheet(string quantity, string itemText)
+    {
+        // The value field is a plain text TextField (testid is on the htmlInput), so Fill works
+        // directly — unlike the masked DatePicker or the unit Select.
+        await ctx.Page.GetByTestId($"promote-row-quantity-value-{itemText}").FillAsync(quantity);
+    }
+
     [When("I clear the expiry date for {string}")]
     public async Task WhenIClearTheExpiryDateFor(string itemText)
     {

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/promote/PromoteReviewSheet.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/promote/PromoteReviewSheet.tsx
@@ -353,60 +353,62 @@ const PromoteRow = ({ entry, draft, onChange, onOmit }: PromoteRowProps) => {
                 </IconButton>
             </Stack>
             <Stack spacing={1} sx={{ mt: 1 }}>
-                {entry.quantity && (
-                    <Stack
-                        direction="row"
-                        spacing={1}
-                        sx={{ alignItems: "center" }}
-                    >
-                        <TextField
-                            size="small"
-                            type="text"
-                            label={t("common.quantity")}
-                            value={draft.quantity.value}
-                            onChange={(e) =>
-                                onChange({
-                                    quantity: {
-                                        ...draft.quantity,
-                                        value: e.target.value,
-                                    },
-                                })
-                            }
-                            error={!isDraftValid(draft.quantity)}
-                            slotProps={{
-                                inputLabel: { shrink: true },
-                                htmlInput: {
-                                    inputMode: "decimal",
-                                    "data-testid": `promote-row-quantity-value-${entry.text}`,
+                {/* Always editable: an item listed without a quantity ("Apples") can still get
+                    one here — you may have bought a specific count. Pre-filled when the source
+                    had a value, empty (with placeholder) otherwise. */}
+                <Stack
+                    direction="row"
+                    spacing={1}
+                    sx={{ alignItems: "center" }}
+                >
+                    <TextField
+                        size="small"
+                        type="text"
+                        label={t("common.quantity")}
+                        placeholder={t("common.quantity")}
+                        value={draft.quantity.value}
+                        onChange={(e) =>
+                            onChange({
+                                quantity: {
+                                    ...draft.quantity,
+                                    value: e.target.value,
                                 },
-                            }}
-                            sx={{ width: 90 }}
-                        />
-                        <TextField
-                            select
-                            size="small"
-                            label={t("common.unit")}
-                            value={draft.quantity.unit}
-                            onChange={(e) =>
-                                onChange({
-                                    quantity: {
-                                        ...draft.quantity,
-                                        unit: e.target.value as QuantityUnit,
-                                    },
-                                })
-                            }
-                            data-testid={`promote-row-quantity-unit-${entry.text}`}
-                            slotProps={{ inputLabel: { shrink: true } }}
-                            sx={{ flex: 1, minWidth: 120 }}
-                        >
-                            {QUANTITY_UNIT_VALUES.map((u) => (
-                                <MenuItem key={u} value={u}>
-                                    {unitLabel(t, u)}
-                                </MenuItem>
-                            ))}
-                        </TextField>
-                    </Stack>
-                )}
+                            })
+                        }
+                        error={!isDraftValid(draft.quantity)}
+                        slotProps={{
+                            inputLabel: { shrink: true },
+                            htmlInput: {
+                                inputMode: "decimal",
+                                "data-testid": `promote-row-quantity-value-${entry.text}`,
+                            },
+                        }}
+                        sx={{ width: 90 }}
+                    />
+                    <TextField
+                        select
+                        size="small"
+                        label={t("common.unit")}
+                        value={draft.quantity.unit}
+                        onChange={(e) =>
+                            onChange({
+                                quantity: {
+                                    ...draft.quantity,
+                                    unit: e.target.value as QuantityUnit,
+                                },
+                            })
+                        }
+                        data-testid={`promote-row-quantity-unit-${entry.text}`}
+                        slotProps={{ inputLabel: { shrink: true } }}
+                        sx={{ flex: 1, minWidth: 120 }}
+                    >
+                        {QUANTITY_UNIT_VALUES.map((u) => (
+                            <MenuItem key={u} value={u}>
+                                {unitLabel(t, u)}
+                            </MenuItem>
+                        ))}
+                    </TextField>
+                </Stack>
                 <ExpiryDatePicker
                     fullWidth
                     value={draft.expiry || null}

--- a/BUGS.md
+++ b/BUGS.md
@@ -14,15 +14,6 @@ focused. Likely fix if confirmed: surface foreground messages as an in-app toast
 
 Deferred from the expiry-notifications feature work (testing feedback item #4).
 
-## Inventory promotion sheet blocks quantity entry when source item had no quantity
-
-When a list item was created without a quantity (e.g. "Apples"), the promotion
-sheet used to promote it to inventory does not allow the user to enter a quantity.
-The intended flow: user lists "Apples" without specifying how many, buys 5 in the
-store, opens the promotion sheet, types 5, and promotes "5 Apples" to inventory.
-The sheet should always render a quantity input, pre-filled with the extracted
-value if one exists and empty/placeholder otherwise.
-
 ## Inventory fails to load when opening a notification for a non-active household
 
 With multiple households: if you receive an expiry notification for Household B


### PR DESCRIPTION
## Problem

When a list item was created without a quantity (e.g. "Apples"), the inventory promotion sheet did not render a quantity input at all, so you couldn't record what you actually bought before promoting it to inventory.

Root cause: `PromoteReviewSheet.tsx` gated the quantity input behind `{entry.quantity && ...}` — the source item having a quantity. The per-row draft was already seeded for the empty case (`EMPTY_QUANTITY_DRAFT`), `isDraftValid("")`/`draftToQuantity("")` already treat empty as "no quantity", and the backend (`PromoteListItems.cs`) already accepts a null quantity. So only the render gate was wrong.

## Fix

- Always render the quantity input — pre-filled when the source had a value, empty (with a placeholder) otherwise.

## Tests

The promotion feature had **no** coverage of the quantity field at all (the happy-path test promoted a no-quantity item but only clicked Add and asserted the text landed — which is why it missed this). Added two Playwright integration scenarios in `Promote.feature`:

1. **Regression guard** — a no-quantity source item shows a quantity input, accepts `5`, and the value lands in the inventory item. Fails pre-fix (input doesn't render), passes post-fix.
2. **Invalid quantity blocks Add** — entering `abc` disables the Add button.

## Verification

- `npm run tsc` + `npm run lint` ✓
- `dotnet test Frigorino.IntegrationTests --filter ~Promote` → 11 passed, 0 failed ✓ (run against a fresh SPA build, since the IT harness serves `ClientApp/build`)
- Removed the resolved entry from `BUGS.md`.