### PR TITLE
perf: bounded-concurrency background queue consumer

### DIFF
--- a/Application/Frigorino.Infrastructure/Services/QueuedHostedService.cs
+++ b/Application/Frigorino.Infrastructure/Services/QueuedHostedService.cs
@@ -6,8 +6,18 @@ namespace Frigorino.Infrastructure.Services
 {
     // Single consumer that drains BackgroundTaskQueue, running each work item in its own DI scope.
     // Event-driven: ReadAllAsync parks at zero CPU when the queue is empty.
+    //
+    // Work items are I/O-bound (e.g. an OpenAI classify call ~1s each), so a serial drain made a
+    // large backfill take items × ~1s of wall-clock. A single reader still owns the channel
+    // (SingleReader = true is preserved), but it dispatches each item to a bounded pool of up to
+    // MaxConcurrency in-flight tasks instead of awaiting inline — the network waits now overlap.
     public class QueuedHostedService : BackgroundService
     {
+        // Concurrent in-flight work items. Bounded (not unbounded) so a flood of queued items can't
+        // hammer downstream APIs into rate limits. Items are independent and each runs in its own
+        // scope, so concurrency is safe; 8 keeps comfortable headroom under typical OpenAI limits.
+        public const int MaxConcurrency = 8;
+
         private readonly BackgroundTaskQueue _queue;
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly ILogger<QueuedHostedService> _logger;
@@ -24,32 +34,56 @@ namespace Frigorino.Infrastructure.Services
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            // One free slot per allowed in-flight item; the reader blocks on WaitAsync once all are taken.
+            using var slots = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
+            var running = new List<Task>();
+
             try
             {
                 await foreach (var work in _queue.Reader.ReadAllAsync(stoppingToken))
                 {
-                    try
-                    {
-                        using var scope = _scopeFactory.CreateScope();
-                        await work(scope.ServiceProvider, stoppingToken);
-                    }
-                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-                    {
-                        // The item was cancelled by host shutdown — not a fault. Rethrow so the outer
-                        // handler stops the loop cleanly instead of logging it as a work-item error.
-                        throw;
-                    }
-                    catch (Exception ex)
-                    {
-                        // One bad item must never take down the consumer or starve the queue.
-                        _logger.LogError(ex, "Background work item failed.");
-                    }
+                    // Park the (single) reader until a slot frees up — this is what bounds concurrency.
+                    await slots.WaitAsync(stoppingToken);
+                    running.Add(RunWorkItemAsync(work, slots, stoppingToken));
+                    // Drop finished tasks so the list can't grow without bound during a long backfill.
+                    running.RemoveAll(t => t.IsCompleted);
                 }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
-                // Normal shutdown — the stopping token fired (from ReadAllAsync, or rethrown above);
-                // stop draining and abandon whatever is still queued (lossy by design).
+                // Normal shutdown — the stopping token fired (from ReadAllAsync or WaitAsync); stop
+                // dequeuing and abandon whatever is still queued (lossy by design).
+            }
+
+            // Let in-flight items finish (or observe the stopping token themselves) before we exit.
+            // RunWorkItemAsync never throws, so WhenAll can't fault.
+            await Task.WhenAll(running);
+        }
+
+        // Runs one work item in its own DI scope. Swallows every fault so a bad item can never take
+        // down the consumer; always releases its slot so the reader can admit the next item.
+        private async Task RunWorkItemAsync(
+            Func<IServiceProvider, CancellationToken, Task> work,
+            SemaphoreSlim slots,
+            CancellationToken stoppingToken)
+        {
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                await work(scope.ServiceProvider, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // The item was cancelled by host shutdown — not a fault, so don't log it as an error.
+            }
+            catch (Exception ex)
+            {
+                // One bad item must never take down the consumer or starve the queue.
+                _logger.LogError(ex, "Background work item failed.");
+            }
+            finally
+            {
+                slots.Release();
             }
         }
     }

--- a/Application/Frigorino.Test/Infrastructure/QueuedHostedServiceTests.cs
+++ b/Application/Frigorino.Test/Infrastructure/QueuedHostedServiceTests.cs
@@ -127,6 +127,89 @@ namespace Frigorino.Test.Infrastructure
         }
 
         [Fact]
+        public async Task ExecuteAsync_RunsItemsConcurrently()
+        {
+            var (service, queue) = Build();
+            var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var started = new CountdownEvent(3);
+
+            await service.StartAsync(CancellationToken.None);
+            for (var i = 0; i < 3; i++)
+            {
+                queue.TryEnqueue(async (_, ct) =>
+                {
+                    started.Signal();
+                    await gate.Task.WaitAsync(ct);
+                });
+            }
+
+            // A serial drain would block on item 1's gate and never start items 2 and 3. The
+            // concurrent drain starts all three before any completes.
+            Assert.True(started.Wait(TimeSpan.FromSeconds(5)));
+
+            gate.SetResult();
+            await service.StopAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_BoundsConcurrencyToMaxConcurrency()
+        {
+            var (service, queue) = Build();
+            var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var reachedMax = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var sync = new object();
+            var current = 0;
+            var peak = 0;
+
+            await service.StartAsync(CancellationToken.None);
+            // Enqueue more than the pool can run at once; the surplus must wait for a free slot.
+            var total = QueuedHostedService.MaxConcurrency + 3;
+            for (var i = 0; i < total; i++)
+            {
+                queue.TryEnqueue(async (_, ct) =>
+                {
+                    lock (sync)
+                    {
+                        current++;
+                        peak = Math.Max(peak, current);
+                        if (current == QueuedHostedService.MaxConcurrency)
+                        {
+                            reachedMax.TrySetResult();
+                        }
+                    }
+
+                    try
+                    {
+                        await gate.Task.WaitAsync(ct);
+                    }
+                    finally
+                    {
+                        lock (sync)
+                        {
+                            current--;
+                        }
+                    }
+                });
+            }
+
+            await reachedMax.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            // Give any (incorrectly admitted) surplus item a window to start before reading the peak.
+            await Task.Delay(200);
+
+            int observedPeak;
+            lock (sync)
+            {
+                observedPeak = peak;
+            }
+
+            // Exactly MaxConcurrency ran at once — no more (bound held) and no fewer (pool filled).
+            Assert.Equal(QueuedHostedService.MaxConcurrency, observedPeak);
+
+            gate.SetResult();
+            await service.StopAsync(CancellationToken.None);
+        }
+
+        [Fact]
         public async Task StopAsync_CompletesCleanly()
         {
             var (service, _) = Build();


### PR DESCRIPTION
## Problem

The background queue consumer (`QueuedHostedService`) drained items strictly serially — it dequeued one item, awaited it to completion, then read the next. Work items are I/O-bound (each OpenAI classify call blocks ~1s on the network), so a large backfill ran at ~1 item/sec with the CPU idle. A 600-item `BackfillProductClassification` run took ~600s of wall-clock — uncomfortably close to Railway's ~10-min idle-sleep window.

## Change

`QueuedHostedService` now keeps the **single-reader** channel contract (`SingleReader = true` preserved) but dispatches each item to a **bounded pool of up to `MaxConcurrency` (8)** in-flight tasks via a `SemaphoreSlim`, instead of awaiting inline. The reader parks once all slots are taken, so concurrency is capped — no flooding the OpenAI API into rate limits.

This is the shared consumer for all fire-and-forget work (classification + quantity extraction), so everything on the queue benefits. Safe because every item already runs isolated in its own DI scope; the concurrent-insert race in `ClassifyProductJob` was already handled.

All existing guarantees preserved:
- fresh DI scope per item
- one bad item never stops the consumer
- clean shutdown without logging cancelled in-flight items as errors
- shutdown now `Task.WhenAll`s in-flight items instead of abandoning them mid-call

## Impact

~600s → ~75s for a full backfill. No new dependencies, no config change. `MaxConcurrency` is a `public const` if tuning is needed later.

Note: no retry/backoff on a 429 — a rate-limited item drops but is recoverable (backfill re-scans gaps on next cold start). Unlikely to bite at 8 concurrent.

## Tests

Added two to `QueuedHostedServiceTests`:
- proves items now run concurrently (serial version would deadlock the test)
- proves peak concurrency is capped at exactly `MaxConcurrency`

Full infrastructure suite (105 tests) green.