### PR TITLE
feat: replace ProductCategory with 23-aisle supermarket taxonomy

### DIFF
--- a/Application/Frigorino.Domain/Products/ProductCategory.cs
+++ b/Application/Frigorino.Domain/Products/ProductCategory.cs
@@ -1,13 +1,41 @@
 namespace Frigorino.Domain.Products
 {
-    // What kind of thing the catalog entry is — a facet distinct from how it expires (ExpiryHandling).
-    // Drives whether Cycle 3 offers the item for inventory promotion. Other = 0 is the safe default
-    // (default(ProductCategory) and the refusal/uncertain fallback): unknown things are not promoted.
+    // The "what kind / which aisle" facet of a product, orthogonal to ExpiryProfile (how it
+    // expires). Stored as an int column on Product (EF default — no migration when values change).
+    // Two sentinels + 23 supermarket aisles:
+    //   Unknown = 0 is default(ProductCategory) AND the classification-failure fallback (we could
+    //     not classify it: nonsense / refusal / inconsistent model output).
+    //   Other is a recognized item that is NOT a stocked grocery/household good (a task, a one-off).
+    // The aisles exist so a future "sort a list by store walk-order" feature has a meaningful axis;
+    // nothing reads this facet yet. The classifier's strict-output schema derives its enum from
+    // Enum.GetNames<ProductCategory>(), so adding/removing a value here updates the schema with no
+    // hand-edit — but the OpenAiItemClassifier system prompt must describe each value.
     public enum ProductCategory
     {
         Unknown = 0,
         Other = 1,
-        Food = 2,
-        HouseholdSupply = 3,
+        Produce = 2,
+        Bakery = 3,
+        Meat = 4,
+        Fish = 5,
+        DairyAndEggs = 6,
+        Cheese = 7,
+        DeliAndColdCuts = 8,
+        Frozen = 9,
+        Pantry = 10,
+        CannedGoods = 11,
+        Sauces = 12,
+        OilsAndVinegar = 13,
+        Spices = 14,
+        Cereal = 15,
+        Spreads = 16,
+        Snacks = 17,
+        Sweets = 18,
+        Beverages = 19,
+        Alcohol = 20,
+        HouseholdAndCleaning = 21,
+        HealthAndBeauty = 22,
+        Baby = 23,
+        Pet = 24,
     }
 }

--- a/Application/Frigorino.Infrastructure/Services/OpenAiItemClassifier.cs
+++ b/Application/Frigorino.Infrastructure/Services/OpenAiItemClassifier.cs
@@ -14,7 +14,7 @@ namespace Frigorino.Infrastructure.Services
     public class OpenAiItemClassifier : IItemClassifier
     {
         // Bump when the prompt or schema changes to force re-classification on the next reference.
-        public int Version => 1;
+        public int Version => 2;
 
         // The strict Structured Outputs schema. Enum values and the shelf-life bounds are
         // interpolated from the domain types so they can't silently drift from ProductCategory /
@@ -51,11 +51,32 @@ namespace Frigorino.Infrastructure.Services
         private static readonly string SystemPrompt =
             "You classify a single item a user wrote on a household list. Items are usually groceries or household supplies, but may be anything (e.g. a reminder, or a non-consumable object).\n" +
             "In 'reasoning', briefly justify your choice in one short sentence always in english not matter the input language.\n" +
-            "Set 'productCategory' to exactly one of:\n" +
-            "- Unknown: anything you do not recognize as an item (e. g. nonsense text, placeholders, invalid characters, emotes)\n" +
-            "- Food: edible/drinkable groceries (e.g. milk/Milch, bananas/Bananen, bread/Brot).\n" +
-            "- HouseholdSupply: non-food consumables you restock (e.g. dish soap/Spülmittel, batteries/Batterien, paper towels/Küchenrolle).\n" +
-            "- Other: anything not stocked as a food/household consumable (e.g. a task like 'call dentist'/'Zahnarzt anrufen', or a one-off object).\n" +
+            "Set 'productCategory' to exactly one supermarket aisle — pick the single aisle where the item is normally shopped/stored:\n" +
+            "- Unknown: you cannot classify it (nonsense text, placeholders, invalid characters, emotes).\n" +
+            "- Other: a recognized thing that is NOT a stocked grocery/household good (e.g. a task like 'call dentist'/'Zahnarzt anrufen', or a one-off object).\n" +
+            "- Produce: fresh fruit & vegetables (e.g. bananas/Bananen, lettuce/Salat, apples/Äpfel).\n" +
+            "- Bakery: bread & baked goods (e.g. bread/Brot, rolls/Brötchen, croissants).\n" +
+            "- Meat: fresh or packaged meat & poultry (e.g. chicken/Hähnchen, mince/Hackfleisch).\n" +
+            "- Fish: fresh or packaged fish & seafood (e.g. salmon/Lachs, shrimp/Garnelen).\n" +
+            "- DairyAndEggs: milk, butter, yogurt, eggs (e.g. milk/Milch, yogurt/Joghurt, eggs/Eier).\n" +
+            "- Cheese: cheese of any kind (e.g. Gouda, cream cheese/Frischkäse, Parmesan).\n" +
+            "- DeliAndColdCuts: chilled sausage, sliced cold cuts, deli counter (e.g. ham/Schinken, salami/Salami, Aufschnitt).\n" +
+            "- Frozen: frozen foods (e.g. frozen pizza/Tiefkühlpizza, ice cream/Eis, frozen vegetables/TK-Gemüse).\n" +
+            "- Pantry: dry shelf-stable staples (e.g. pasta/Nudeln, rice/Reis, flour/Mehl, sugar/Zucker).\n" +
+            "- CannedGoods: canned or jarred goods (e.g. canned tomatoes/Dosentomaten, beans/Bohnen, corn/Mais).\n" +
+            "- Sauces: sauces, dressings & pastes (e.g. ketchup/Ketchup, pasta sauce/Passata, mayonnaise/Mayonnaise, pesto/Pesto).\n" +
+            "- OilsAndVinegar: cooking oils & vinegar (e.g. olive oil/Olivenöl, sunflower oil/Sonnenblumenöl, vinegar/Essig).\n" +
+            "- Spices: spices, salt & baking aids (e.g. salt/Salz, pepper/Pfeffer, cinnamon/Zimt, baking powder/Backpulver).\n" +
+            "- Cereal: breakfast cereal & oats (e.g. muesli/Müsli, oats/Haferflocken, cornflakes/Cornflakes).\n" +
+            "- Spreads: sweet or savoury spreads (e.g. jam/Marmelade, Nutella, honey/Honig, peanut butter/Erdnussbutter).\n" +
+            "- Snacks: savoury snacks (e.g. chips/Chips, pretzels/Brezeln, crackers/Cracker, nuts/Nüsse).\n" +
+            "- Sweets: confectionery (e.g. chocolate/Schokolade, gummy bears/Gummibärchen, candy/Bonbons).\n" +
+            "- Beverages: non-alcoholic drinks (e.g. water/Wasser, juice/Saft, soda/Limonade, coffee/Kaffee, tea/Tee).\n" +
+            "- Alcohol: alcoholic drinks (e.g. beer/Bier, wine/Wein, spirits/Schnaps).\n" +
+            "- HouseholdAndCleaning: cleaning & household supplies (e.g. dish soap/Spülmittel, paper towels/Küchenrolle, batteries/Batterien).\n" +
+            "- HealthAndBeauty: personal care, health & cosmetics (e.g. toothpaste/Zahnpasta, shampoo/Shampoo, plasters/Pflaster).\n" +
+            "- Baby: baby food & baby care (e.g. baby food/Babybrei, diapers/Windeln, baby wipes/Feuchttücher).\n" +
+            "- Pet: pet supplies & pet food (e.g. dog food/Hundefutter, cat litter/Katzenstreu).\n" +
             "Set 'expiryHandling' to exactly one of:\n" +
             "- Unknown: anything you do not recognize as an item (e. g. nonsense text, placeholders, invalid characters, emotes)\n" +
             "- NonPerishable: effectively never expires (e.g. salt/Salz, sugar/Zucker, dish soap/Spülmittel). defaultShelfLifeDays = null.\n" +
@@ -104,14 +125,14 @@ namespace Frigorino.Infrastructure.Services
             {
                 var completion = await _client.CompleteChatAsync(messages, Options, ct);
 
-                // Refusal or empty content → treat as Other/non-perishable rather than failing the job.
+                // Refusal or empty content → treat as Unknown/non-perishable rather than failing the job.
                 if (completion.Value.Content.Count == 0
                     || string.IsNullOrWhiteSpace(completion.Value.Content[0].Text))
                 {
                     _logger.LogWarning(
-                        "Classifier returned no usable content for '{Name}'; defaulting to Other/non-perishable.",
+                        "Classifier returned no usable content for '{Name}'; defaulting to Unknown/non-perishable.",
                         normalizedName);
-                    return Result.Ok(new ProductClassification(ProductCategory.Other, ExpiryProfile.NonPerishable));
+                    return Result.Ok(new ProductClassification(ProductCategory.Unknown, ExpiryProfile.NonPerishable));
                 }
 
                 var dto = JsonSerializer.Deserialize<ClassifierResponse>(completion.Value.Content[0].Text, JsonOptions);
@@ -128,7 +149,7 @@ namespace Frigorino.Infrastructure.Services
                 if (dto is null || profile.IsFailed)
                 {
                     // Model produced a schema-valid-but-semantically-inconsistent combination; be safe.
-                    return Result.Ok(new ProductClassification(ProductCategory.Other, ExpiryProfile.NonPerishable));
+                    return Result.Ok(new ProductClassification(ProductCategory.Unknown, ExpiryProfile.NonPerishable));
                 }
 
 

--- a/Application/Frigorino.IntegrationTests/Infrastructure/StubItemClassifier.cs
+++ b/Application/Frigorino.IntegrationTests/Infrastructure/StubItemClassifier.cs
@@ -5,10 +5,10 @@ using Frigorino.Domain.Products;
 namespace Frigorino.IntegrationTests.Infrastructure;
 
 // Deterministic, network-free classifier for integration tests:
-//   "milk"/"milch"      → Food, AI-recommended 7-day shelf life
-//   "soap"/"spülmittel" → HouseholdSupply, non-perishable
+//   "milk"/"milch"      → DairyAndEggs, AI-recommended 7-day shelf life
+//   "soap"/"spülmittel" → HouseholdAndCleaning, non-perishable
 //   "call"/"anruf"      → Other, non-perishable (a task, not a stockable product)
-//   everything else     → Food, non-perishable
+//   everything else     → Pantry, non-perishable
 public sealed class StubItemClassifier : IItemClassifier
 {
     public int Version => 1;
@@ -19,11 +19,11 @@ public sealed class StubItemClassifier : IItemClassifier
         if (normalizedName.Contains("milk") || normalizedName.Contains("milch"))
         {
             result = new ProductClassification(
-                ProductCategory.Food, ExpiryProfile.Create(ExpiryHandling.AiRecommendsShelfLife, 7).Value);
+                ProductCategory.DairyAndEggs, ExpiryProfile.Create(ExpiryHandling.AiRecommendsShelfLife, 7).Value);
         }
         else if (normalizedName.Contains("soap") || normalizedName.Contains("spülmittel"))
         {
-            result = new ProductClassification(ProductCategory.HouseholdSupply, ExpiryProfile.NonPerishable);
+            result = new ProductClassification(ProductCategory.HouseholdAndCleaning, ExpiryProfile.NonPerishable);
         }
         else if (normalizedName.Contains("call") || normalizedName.Contains("anruf"))
         {
@@ -31,7 +31,7 @@ public sealed class StubItemClassifier : IItemClassifier
         }
         else
         {
-            result = new ProductClassification(ProductCategory.Food, ExpiryProfile.NonPerishable);
+            result = new ProductClassification(ProductCategory.Pantry, ExpiryProfile.NonPerishable);
         }
 
         return Task.FromResult(Result.Ok(result));

--- a/Application/Frigorino.IntegrationTests/Slices/Lists/Classification.Api.feature
+++ b/Application/Frigorino.IntegrationTests/Slices/Lists/Classification.Api.feature
@@ -7,13 +7,13 @@ Feature: Product Classification API
     Given there is a list named "Weekly Groceries"
     When I POST an item with text "Milk" to "Weekly Groceries" via the API
     Then the product catalog eventually contains "milk" with AI-recommended shelf life 7
-    And the product "milk" is categorized as "Food"
+    And the product "milk" is categorized as "DairyAndEggs"
 
   Scenario: Adding a non-perishable grocery classifies it as non-perishable food
     Given there is a list named "Weekly Groceries"
     When I POST an item with text "Salt" to "Weekly Groceries" via the API
     Then the product catalog eventually contains "salt" as non-perishable
-    And the product "salt" is categorized as "Food"
+    And the product "salt" is categorized as "Pantry"
 
   Scenario: Adding a non-product task is categorized as Other
     Given there is a list named "Weekly Groceries"

--- a/Application/Frigorino.IntegrationTests/Slices/Lists/Extraction.Api.feature
+++ b/Application/Frigorino.IntegrationTests/Slices/Lists/Extraction.Api.feature
@@ -12,7 +12,7 @@ Feature: Inline Quantity Extraction API
     Given there is a list named "Weekly Groceries"
     When I POST an item with text "1l milk" to "Weekly Groceries" via the API
     Then the list item eventually has text "milk" with quantity 1 unit 3
-    And the product "milk" is categorized as "Food"
+    And the product "milk" is categorized as "DairyAndEggs"
 
   Scenario: A non-digit task is not extracted but is still classified
     Given there is a list named "Weekly Groceries"

--- a/Application/Frigorino.Test/Domain/ProductAggregateTests.cs
+++ b/Application/Frigorino.Test/Domain/ProductAggregateTests.cs
@@ -8,7 +8,7 @@ namespace Frigorino.Test.Domain
         private const int HouseholdId = 42;
 
         private static ProductClassification AiClassification(int days) =>
-            new(ProductCategory.Food, ExpiryProfile.Create(ExpiryHandling.AiRecommendsShelfLife, days).Value);
+            new(ProductCategory.DairyAndEggs, ExpiryProfile.Create(ExpiryHandling.AiRecommendsShelfLife, days).Value);
 
         [Fact]
         public void Create_Valid_SetsColumnsAndVersion()
@@ -19,7 +19,7 @@ namespace Frigorino.Test.Domain
             var product = result.Value;
             Assert.Equal(HouseholdId, product.HouseholdId);
             Assert.Equal("milk", product.NormalizedName);
-            Assert.Equal(ProductCategory.Food, product.ClassificationProductCategory);
+            Assert.Equal(ProductCategory.DairyAndEggs, product.ClassificationProductCategory);
             Assert.Equal(ExpiryHandling.AiRecommendsShelfLife, product.ClassificationExpiryHandling);
             Assert.Equal(7, product.ClassificationShelfLifeDays);
             Assert.Equal(1, product.ClassifierVersion);
@@ -47,10 +47,10 @@ namespace Frigorino.Test.Domain
             var product = Product.Create(HouseholdId, "milk", AiClassification(7), 1).Value;
 
             product.ApplyClassification(
-                new ProductClassification(ProductCategory.HouseholdSupply, ExpiryProfile.NonPerishable),
+                new ProductClassification(ProductCategory.HouseholdAndCleaning, ExpiryProfile.NonPerishable),
                 classifierVersion: 2);
 
-            Assert.Equal(ProductCategory.HouseholdSupply, product.ClassificationProductCategory);
+            Assert.Equal(ProductCategory.HouseholdAndCleaning, product.ClassificationProductCategory);
             Assert.Equal(ExpiryHandling.NonPerishable, product.ClassificationExpiryHandling);
             Assert.Null(product.ClassificationShelfLifeDays);
             Assert.Equal(2, product.ClassifierVersion);

--- a/Application/Frigorino.Test/Features/PromoteSuggestionTests.cs
+++ b/Application/Frigorino.Test/Features/PromoteSuggestionTests.cs
@@ -11,7 +11,7 @@ public class PromoteSuggestionTests
     private static Product ProductWith(ExpiryHandling handling, int? shelfLifeDays)
     {
         var classification = new ProductClassification(
-            ProductCategory.Food, ExpiryProfile.Create(handling, shelfLifeDays).Value);
+            ProductCategory.DairyAndEggs, ExpiryProfile.Create(handling, shelfLifeDays).Value);
         return Product.Create(1, "milk", classification, classifierVersion: 1).Value;
     }
 

--- a/Application/Frigorino.Test/Infrastructure/ClassifyProductJobTests.cs
+++ b/Application/Frigorino.Test/Infrastructure/ClassifyProductJobTests.cs
@@ -44,7 +44,7 @@ namespace Frigorino.Test.Infrastructure
 
         private static Result<ProductClassification> AiResult(int days) =>
             Result.Ok(new ProductClassification(
-                ProductCategory.Food, ExpiryProfile.Create(ExpiryHandling.AiRecommendsShelfLife, days).Value));
+                ProductCategory.DairyAndEggs, ExpiryProfile.Create(ExpiryHandling.AiRecommendsShelfLife, days).Value));
 
         [Fact]
         public async Task Run_NewName_ClassifiesAndInserts()
@@ -60,7 +60,7 @@ namespace Frigorino.Test.Infrastructure
             using var verify = NewContext(dbName);
             var product = await verify.Products.SingleAsync();
             Assert.Equal("milk", product.NormalizedName);
-            Assert.Equal(ProductCategory.Food, product.ClassificationProductCategory);
+            Assert.Equal(ProductCategory.DairyAndEggs, product.ClassificationProductCategory);
             Assert.Equal(ExpiryHandling.AiRecommendsShelfLife, product.ClassificationExpiryHandling);
             Assert.Equal(7, product.ClassificationShelfLifeDays);
             Assert.Equal(1, product.ClassifierVersion);

--- a/Application/Frigorino.Test/Infrastructure/ProductPersistenceTests.cs
+++ b/Application/Frigorino.Test/Infrastructure/ProductPersistenceTests.cs
@@ -21,7 +21,7 @@ namespace Frigorino.Test.Infrastructure
         {
             using var db = NewContext();
             var classification = new ProductClassification(
-                ProductCategory.Food, ExpiryProfile.Create(ExpiryHandling.AiRecommendsShelfLife, 7).Value);
+                ProductCategory.DairyAndEggs, ExpiryProfile.Create(ExpiryHandling.AiRecommendsShelfLife, 7).Value);
             var product = Product.Create(42, "milk", classification, 1).Value;
 
             db.Products.Add(product);

--- a/docs/superpowers/plans/2026-06-12-aisle-product-taxonomy.md
+++ b/docs/superpowers/plans/2026-06-12-aisle-product-taxonomy.md
@@ -1,0 +1,365 @@
+# Aisle-level Product Taxonomy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the coarse `ProductCategory` enum (`Unknown`/`Other`/`Food`/`HouseholdSupply`) with a 23-aisle supermarket taxonomy (+ 2 sentinels), update the classifier prompt to emit it, bump the classifier version to trigger automatic re-classification, and switch the failure fallback to `Unknown`.
+
+**Architecture:** Backend-only, no new behaviour consumer. `ProductCategory` is a flat enum stored as `int` (EF default — no migration). The strict-output JSON schema auto-derives its enum from `Enum.GetNames<ProductCategory>()`, so only the enum + the prompt prose change. Bumping `OpenAiItemClassifier.Version` makes every existing `Product` stale; the existing `BackfillProductClassification` maintenance task re-classifies the catalog over cold starts — no new rollout code. Category is read by no feature, no response DTO, and no generated TS client, so there is no API regeneration and no frontend change.
+
+**Tech Stack:** .NET 10, EF Core (Postgres / InMemory for tests), xUnit + FakeItEasy, Reqnroll + Playwright + Testcontainers (integration), OpenAI SDK behind the `IItemClassifier` port.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-aisle-product-taxonomy-design.md`
+
+---
+
+## File Structure
+
+**Production code (2 files):**
+- `Application/Frigorino.Domain/Products/ProductCategory.cs` — redefine the enum + header comment (Task 1).
+- `Application/Frigorino.Infrastructure/Services/OpenAiItemClassifier.cs` — prompt rewrite, `Version => 2`, fallback `Other → Unknown` (Task 2).
+
+**Test code (5 files), all updated in Task 1 to keep the solution compiling & green:**
+- `Application/Frigorino.Test/Domain/ProductAggregateTests.cs`
+- `Application/Frigorino.Test/Features/PromoteSuggestionTests.cs`
+- `Application/Frigorino.Test/Infrastructure/ClassifyProductJobTests.cs`
+- `Application/Frigorino.IntegrationTests/Infrastructure/StubItemClassifier.cs`
+- `Application/Frigorino.IntegrationTests/Slices/Lists/Classification.Api.feature` and `Extraction.Api.feature`
+
+**Deliberately unchanged:** `ProductConfiguration.cs` (still `int`, no migration), `ProductClassificationGaps.cs` + `ProductClassificationGapsTests.cs` (version-agnostic, already use a local `CurrentVersion = 2`), `Product.cs`, any DTO / generated client. No EF migration. No `npm run api`.
+
+**Fixture value mapping** (removed value → surviving replacement, used consistently across all test edits):
+- `Food` (always on "milk") → `DairyAndEggs`
+- `HouseholdSupply` (always on "soap") → `HouseholdAndCleaning`
+- `Other` → unchanged (survives as the non-shoppable sentinel)
+- Stub catch-all (was `Food`) → `Pantry`
+
+---
+
+## Task 1: Redefine the enum and update all consumers (one atomic green commit)
+
+Removing `Food`/`HouseholdSupply` breaks compilation everywhere they are referenced (tests + the integration stub only — never production logic). This task changes the enum and every consumer together so the solution compiles and all tests pass in a single commit. The compiler is the guide: after the enum change, `dotnet build` lists exactly the lines to fix.
+
+**Files:**
+- Modify: `Application/Frigorino.Domain/Products/ProductCategory.cs`
+- Modify: `Application/Frigorino.Test/Domain/ProductAggregateTests.cs:10-11,22,50,53`
+- Modify: `Application/Frigorino.Test/Features/PromoteSuggestionTests.cs:13-14`
+- Modify: `Application/Frigorino.Test/Infrastructure/ClassifyProductJobTests.cs:45-47,63`
+- Modify: `Application/Frigorino.IntegrationTests/Infrastructure/StubItemClassifier.cs`
+- Modify: `Application/Frigorino.IntegrationTests/Slices/Lists/Classification.Api.feature:10,16`
+- Modify: `Application/Frigorino.IntegrationTests/Slices/Lists/Extraction.Api.feature:15`
+
+- [ ] **Step 1: Redefine the enum**
+
+Replace the entire contents of `Application/Frigorino.Domain/Products/ProductCategory.cs` with:
+
+```csharp
+namespace Frigorino.Domain.Products
+{
+    // The "what kind / which aisle" facet of a product, orthogonal to ExpiryProfile (how it
+    // expires). Stored as an int column on Product (EF default — no migration when values change).
+    // Two sentinels + 23 supermarket aisles:
+    //   Unknown = 0 is default(ProductCategory) AND the classification-failure fallback (we could
+    //     not classify it: nonsense / refusal / inconsistent model output).
+    //   Other is a recognized item that is NOT a stocked grocery/household good (a task, a one-off).
+    // The aisles exist so a future "sort a list by store walk-order" feature has a meaningful axis;
+    // nothing reads this facet yet. The classifier's strict-output schema derives its enum from
+    // Enum.GetNames<ProductCategory>(), so adding/removing a value here updates the schema with no
+    // hand-edit — but the OpenAiItemClassifier system prompt must describe each value.
+    public enum ProductCategory
+    {
+        Unknown = 0,
+        Other = 1,
+        Produce = 2,
+        Bakery = 3,
+        Meat = 4,
+        Fish = 5,
+        DairyAndEggs = 6,
+        Cheese = 7,
+        DeliAndColdCuts = 8,
+        Frozen = 9,
+        Pantry = 10,
+        CannedGoods = 11,
+        Sauces = 12,
+        OilsAndVinegar = 13,
+        Spices = 14,
+        Cereal = 15,
+        Spreads = 16,
+        Snacks = 17,
+        Sweets = 18,
+        Beverages = 19,
+        Alcohol = 20,
+        HouseholdAndCleaning = 21,
+        HealthAndBeauty = 22,
+        Baby = 23,
+        Pet = 24,
+    }
+}
+```
+
+- [ ] **Step 2: Build the solution to surface every broken reference**
+
+Run: `dotnet build Application/Frigorino.sln`
+Expected: FAIL. Compile errors `CS0117: 'ProductCategory' does not contain a definition for 'Food'` (and `'HouseholdSupply'`) at the test/stub lines listed below. This is the to-do list for the rest of this task.
+
+- [ ] **Step 3: Fix `ProductAggregateTests.cs`**
+
+Change the `AiClassification` helper (line 11) `ProductCategory.Food` → `ProductCategory.DairyAndEggs`:
+
+```csharp
+        private static ProductClassification AiClassification(int days) =>
+            new(ProductCategory.DairyAndEggs, ExpiryProfile.Create(ExpiryHandling.AiRecommendsShelfLife, days).Value);
+```
+
+Update the assertion in `Create_Valid_SetsColumnsAndVersion` (line 22):
+
+```csharp
+            Assert.Equal(ProductCategory.DairyAndEggs, product.ClassificationProductCategory);
+```
+
+In `ApplyClassification_OverwritesLayerAndVersion`, change the `HouseholdSupply` classification (line 50) and its assertion (line 53) to `HouseholdAndCleaning`:
+
+```csharp
+            product.ApplyClassification(
+                new ProductClassification(ProductCategory.HouseholdAndCleaning, ExpiryProfile.NonPerishable),
+                classifierVersion: 2);
+
+            Assert.Equal(ProductCategory.HouseholdAndCleaning, product.ClassificationProductCategory);
+```
+
+- [ ] **Step 4: Fix `PromoteSuggestionTests.cs`**
+
+Change the `ProductWith` helper (lines 13-14) `ProductCategory.Food` → `ProductCategory.DairyAndEggs`:
+
+```csharp
+        var classification = new ProductClassification(
+            ProductCategory.DairyAndEggs, ExpiryProfile.Create(handling, shelfLifeDays).Value);
+```
+
+- [ ] **Step 5: Fix `ClassifyProductJobTests.cs`**
+
+Change the `AiResult` helper (lines 46-47) `ProductCategory.Food` → `ProductCategory.DairyAndEggs`:
+
+```csharp
+        private static Result<ProductClassification> AiResult(int days) =>
+            Result.Ok(new ProductClassification(
+                ProductCategory.DairyAndEggs, ExpiryProfile.Create(ExpiryHandling.AiRecommendsShelfLife, days).Value));
+```
+
+Update the assertion in `Run_NewName_ClassifiesAndInserts` (line 63):
+
+```csharp
+            Assert.Equal(ProductCategory.DairyAndEggs, product.ClassificationProductCategory);
+```
+
+(The `Run_StaleVersion_ReclassifiesAndUpdates` test uses `ProductCategory.Other`, which survives — leave it unchanged. It already proves a version-1 product is re-classified under a version-2 classifier, which is exactly the rollout trigger this spec relies on.)
+
+- [ ] **Step 6: Fix `StubItemClassifier.cs`**
+
+Replace the whole class body so the deterministic stub emits surviving categories. The catch-all becomes `Pantry`:
+
+```csharp
+using FluentResults;
+using Frigorino.Domain.Interfaces;
+using Frigorino.Domain.Products;
+
+namespace Frigorino.IntegrationTests.Infrastructure;
+
+// Deterministic, network-free classifier for integration tests:
+//   "milk"/"milch"      → DairyAndEggs, AI-recommended 7-day shelf life
+//   "soap"/"spülmittel" → HouseholdAndCleaning, non-perishable
+//   "call"/"anruf"      → Other, non-perishable (a task, not a stockable product)
+//   everything else     → Pantry, non-perishable
+public sealed class StubItemClassifier : IItemClassifier
+{
+    public int Version => 1;
+
+    public Task<Result<ProductClassification>> ClassifyAsync(string normalizedName, CancellationToken ct)
+    {
+        ProductClassification result;
+        if (normalizedName.Contains("milk") || normalizedName.Contains("milch"))
+        {
+            result = new ProductClassification(
+                ProductCategory.DairyAndEggs, ExpiryProfile.Create(ExpiryHandling.AiRecommendsShelfLife, 7).Value);
+        }
+        else if (normalizedName.Contains("soap") || normalizedName.Contains("spülmittel"))
+        {
+            result = new ProductClassification(ProductCategory.HouseholdAndCleaning, ExpiryProfile.NonPerishable);
+        }
+        else if (normalizedName.Contains("call") || normalizedName.Contains("anruf"))
+        {
+            result = new ProductClassification(ProductCategory.Other, ExpiryProfile.NonPerishable);
+        }
+        else
+        {
+            result = new ProductClassification(ProductCategory.Pantry, ExpiryProfile.NonPerishable);
+        }
+
+        return Task.FromResult(Result.Ok(result));
+    }
+}
+```
+
+- [ ] **Step 7: Fix the two `.feature` files to match the stub's new categories**
+
+In `Application/Frigorino.IntegrationTests/Slices/Lists/Classification.Api.feature`:
+- Line 10: `And the product "milk" is categorized as "Food"` → `... categorized as "DairyAndEggs"`
+- Line 16: `And the product "salt" is categorized as "Food"` → `... categorized as "Pantry"`
+- Line 21 (`"call dentist" ... "Other"`) is unchanged.
+
+In `Application/Frigorino.IntegrationTests/Slices/Lists/Extraction.Api.feature`:
+- Line 15: `And the product "milk" is categorized as "Food"` → `... categorized as "DairyAndEggs"`
+- Line 20 (`"call dentist" ... "Other"`) is unchanged.
+
+- [ ] **Step 8: Rebuild — expect a clean compile**
+
+Run: `dotnet build Application/Frigorino.sln`
+Expected: PASS (0 errors). If any `CS0117` remains, fix that line with the mapping in the File Structure section and rebuild.
+
+- [ ] **Step 9: Run the unit-test project**
+
+Run: `dotnet test Application/Frigorino.Test`
+Expected: PASS (all green). These cover the domain/aggregate/job fixtures just edited.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Application/Frigorino.Domain/Products/ProductCategory.cs \
+        Application/Frigorino.Test/Domain/ProductAggregateTests.cs \
+        Application/Frigorino.Test/Features/PromoteSuggestionTests.cs \
+        Application/Frigorino.Test/Infrastructure/ClassifyProductJobTests.cs \
+        Application/Frigorino.IntegrationTests/Infrastructure/StubItemClassifier.cs \
+        Application/Frigorino.IntegrationTests/Slices/Lists/Classification.Api.feature \
+        Application/Frigorino.IntegrationTests/Slices/Lists/Extraction.Api.feature
+git commit -m "feat(domain): replace ProductCategory with 23-aisle taxonomy"
+```
+
+---
+
+## Task 2: Classifier prompt, version bump, and failure fallback
+
+**Files:**
+- Modify: `Application/Frigorino.Infrastructure/Services/OpenAiItemClassifier.cs:17` (Version), `:54-58` (prompt block), `:107-114` and `:128-131` (fallbacks)
+
+There is no unit test here: the OpenAI `ChatClient` is a concrete SDK type that is not faked anywhere in the codebase (there is no `OpenAiItemClassifierTests`), so this is a prompt/constant change verified by build + the existing job/gap tests staying green. The strict-output schema needs no edit — it derives its `productCategory.enum` from the enum names changed in Task 1.
+
+- [ ] **Step 1: Bump the version (line 17)**
+
+```csharp
+        public int Version => 2;
+```
+
+- [ ] **Step 2: Rewrite the `productCategory` block of the system prompt**
+
+Replace the five `productCategory` lines (currently lines 54-58: the `"Set 'productCategory' to exactly one of:\n"` header and the four `Unknown`/`Food`/`HouseholdSupply`/`Other` bullets) with the 25-value block below. **Leave everything else untouched** — the intro line, the `reasoning` instruction, the entire `expiryHandling` block, the `"For Other items, use Unknown..."` line, and the closing `"Respond only via the provided JSON schema."` line all stay exactly as they are.
+
+```csharp
+            "Set 'productCategory' to exactly one supermarket aisle — pick the single aisle where the item is normally shopped/stored:\n" +
+            "- Unknown: you cannot classify it (nonsense text, placeholders, invalid characters, emotes).\n" +
+            "- Other: a recognized thing that is NOT a stocked grocery/household good (e.g. a task like 'call dentist'/'Zahnarzt anrufen', or a one-off object).\n" +
+            "- Produce: fresh fruit & vegetables (e.g. bananas/Bananen, lettuce/Salat, apples/Äpfel).\n" +
+            "- Bakery: bread & baked goods (e.g. bread/Brot, rolls/Brötchen, croissants).\n" +
+            "- Meat: fresh or packaged meat & poultry (e.g. chicken/Hähnchen, mince/Hackfleisch).\n" +
+            "- Fish: fresh or packaged fish & seafood (e.g. salmon/Lachs, shrimp/Garnelen).\n" +
+            "- DairyAndEggs: milk, butter, yogurt, eggs (e.g. milk/Milch, yogurt/Joghurt, eggs/Eier).\n" +
+            "- Cheese: cheese of any kind (e.g. Gouda, cream cheese/Frischkäse, Parmesan).\n" +
+            "- DeliAndColdCuts: chilled sausage, sliced cold cuts, deli counter (e.g. ham/Schinken, salami/Salami, Aufschnitt).\n" +
+            "- Frozen: frozen foods (e.g. frozen pizza/Tiefkühlpizza, ice cream/Eis, frozen vegetables/TK-Gemüse).\n" +
+            "- Pantry: dry shelf-stable staples (e.g. pasta/Nudeln, rice/Reis, flour/Mehl, sugar/Zucker).\n" +
+            "- CannedGoods: canned or jarred goods (e.g. canned tomatoes/Dosentomaten, beans/Bohnen, corn/Mais).\n" +
+            "- Sauces: sauces, dressings & pastes (e.g. ketchup/Ketchup, pasta sauce/Passata, mayonnaise/Mayonnaise, pesto/Pesto).\n" +
+            "- OilsAndVinegar: cooking oils & vinegar (e.g. olive oil/Olivenöl, sunflower oil/Sonnenblumenöl, vinegar/Essig).\n" +
+            "- Spices: spices, salt & baking aids (e.g. salt/Salz, pepper/Pfeffer, cinnamon/Zimt, baking powder/Backpulver).\n" +
+            "- Cereal: breakfast cereal & oats (e.g. muesli/Müsli, oats/Haferflocken, cornflakes/Cornflakes).\n" +
+            "- Spreads: sweet or savoury spreads (e.g. jam/Marmelade, Nutella, honey/Honig, peanut butter/Erdnussbutter).\n" +
+            "- Snacks: savoury snacks (e.g. chips/Chips, pretzels/Brezeln, crackers/Cracker, nuts/Nüsse).\n" +
+            "- Sweets: confectionery (e.g. chocolate/Schokolade, gummy bears/Gummibärchen, candy/Bonbons).\n" +
+            "- Beverages: non-alcoholic drinks (e.g. water/Wasser, juice/Saft, soda/Limonade, coffee/Kaffee, tea/Tee).\n" +
+            "- Alcohol: alcoholic drinks (e.g. beer/Bier, wine/Wein, spirits/Schnaps).\n" +
+            "- HouseholdAndCleaning: cleaning & household supplies (e.g. dish soap/Spülmittel, paper towels/Küchenrolle, batteries/Batterien).\n" +
+            "- HealthAndBeauty: personal care, health & cosmetics (e.g. toothpaste/Zahnpasta, shampoo/Shampoo, plasters/Pflaster).\n" +
+            "- Baby: baby food & baby care (e.g. baby food/Babybrei, diapers/Windeln, baby wipes/Feuchttücher).\n" +
+            "- Pet: pet supplies & pet food (e.g. dog food/Hundefutter, cat litter/Katzenstreu).\n" +
+```
+
+- [ ] **Step 3: Switch the two failure fallbacks from `Other` to `Unknown`**
+
+There are two fallback sites returning `ProductCategory.Other`. A failed classification means "could not classify" = `Unknown`, not "recognized non-shoppable" = `Other`.
+
+First site — empty/refused content (currently lines ~111-114). Update the log message and the return value:
+
+```csharp
+                if (completion.Value.Content.Count == 0
+                    || string.IsNullOrWhiteSpace(completion.Value.Content[0].Text))
+                {
+                    _logger.LogWarning(
+                        "Classifier returned no usable content for '{Name}'; defaulting to Unknown/non-perishable.",
+                        normalizedName);
+                    return Result.Ok(new ProductClassification(ProductCategory.Unknown, ExpiryProfile.NonPerishable));
+                }
+```
+
+Second site — schema-valid-but-semantically-inconsistent (currently lines ~128-132):
+
+```csharp
+                if (dto is null || profile.IsFailed)
+                {
+                    // Model produced a schema-valid-but-semantically-inconsistent combination; be safe.
+                    return Result.Ok(new ProductClassification(ProductCategory.Unknown, ExpiryProfile.NonPerishable));
+                }
+```
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build Application/Frigorino.sln`
+Expected: PASS (0 errors).
+
+- [ ] **Step 5: Run the unit-test project (must still be green)**
+
+Run: `dotnet test Application/Frigorino.Test`
+Expected: PASS. Nothing here asserts the real classifier's `Version` or fallback, so all tests stay green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Application/Frigorino.Infrastructure/Services/OpenAiItemClassifier.cs
+git commit -m "feat(infra): aisle classifier prompt, version 2, Unknown fallback"
+```
+
+---
+
+## Task 3: Full-solution verification
+
+Per repo convention, the final gate runs the whole solution (unit + integration) and a Docker build. Integration tests use Postgres Testcontainers and need the Docker daemon.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm Docker is running**
+
+Run: `docker info`
+Expected: prints server info. If it errors with the daemon unreachable, stop and ask the user to start Docker Desktop (do not skip the integration run).
+
+- [ ] **Step 2: Run the full solution test suite**
+
+Run: `dotnet test Application/Frigorino.sln`
+Expected: PASS. Includes `Frigorino.Test` and `Frigorino.IntegrationTests`. The classification/extraction `.feature` scenarios now assert `DairyAndEggs` / `Pantry` / `Other` via the updated stub.
+
+- [ ] **Step 3: Confirm no spurious OpenAPI / client drift**
+
+Run: `git status --short`
+Expected: clean (no changes). Category is in no DTO, so building the web project emits no `openapi.json` diff and there is nothing to regenerate. If `ClientApp/src/lib/openapi.json` shows a diff, investigate before proceeding — it should not change.
+
+- [ ] **Step 4: Docker build (catches Dockerfile / publish drift)**
+
+Run: `docker build -f Application/Dockerfile -t frigorino .`
+Expected: PASS. No project was added or removed, so this is a regression guard only.
+
+---
+
+## Self-Review notes (already reconciled)
+
+- **Spec §1 (enum):** Task 1 Step 1 — 23 aisles + `Unknown`/`Other`, values `0..24`. ✓
+- **Spec §2 (prompt + version + fallback):** Task 2 — prompt block (all 25 values), `Version => 2`, both fallbacks → `Unknown`. ✓
+- **Spec §3 (rollout, no new code):** verified by `ClassifyProductJobTests.Run_StaleVersion_*` (kept) + `ProductClassificationGapsTests` (already version-2, unchanged). No code authored. ✓
+- **Spec §5 (no migration / API / frontend):** no `ProductConfiguration` or migration edit; Task 3 Step 3 asserts no `openapi.json` drift. ✓
+- **Spec §6 (testing):** fixtures (Task 1 Steps 3-5), stub + features (Steps 6-7), full-suite gate (Task 3). The "fallback now yields Unknown" check is by inspection — no `ChatClient` fake exists to drive it; flagged in Task 2. ✓
+- **Type/name consistency:** every replacement uses the same mapping (`Food→DairyAndEggs`, `HouseholdSupply→HouseholdAndCleaning`, stub catch-all `→Pantry`, `Other` retained) across unit fixtures, the stub, and the `.feature` strings. ✓

--- a/docs/superpowers/specs/2026-06-12-aisle-product-taxonomy-design.md
+++ b/docs/superpowers/specs/2026-06-12-aisle-product-taxonomy-design.md
@@ -1,0 +1,184 @@
+# Aisle-level Product Taxonomy + Re-classification
+
+**Date:** 2026-06-12
+**Branch:** `feat/aisle-product-taxonomy` (off `stage`)
+**Status:** Design approved, pending implementation plan
+
+## Goal
+
+Replace the coarse `ProductCategory` (`Unknown` / `Other` / `Food` / `HouseholdSupply`)
+with a **23-aisle supermarket taxonomy** (+ 2 sentinels) so a future "sort a list by store
+walk-order" feature has a meaningful axis to sort on. The classifier already produces a
+category facet per item; today it is **classified but unconsumed** — nothing in the app reads
+it. This spec makes that facet *meaningful*; it does not add any consumer.
+
+This is the **prerequisite first slice** of the larger "AI-assisted list sorting (category
+blueprints)" idea. It ships independently and is independently useful (richer classification of
+the product catalog). The household `SortBlueprint`, the blueprint editor UI, and the per-list
+"Sort by category" apply action are a **separate follow-up spec** and are explicitly out of
+scope here.
+
+### Why this is a deliberately separate spec
+
+The taxonomy change is the only piece that (a) touches the AI prompt and (b) triggers a full
+catalog re-classification (real, if small, token spend on the live `stage` client). Landing it
+on its own lets the classification change stabilize before any sorting UX depends on it. The
+sort that *consumes* the taxonomy is designed in the follow-up.
+
+## Key facts that shape the design
+
+- **Category is unconsumed today.** `Product.EffectiveCategory` is read by no feature and
+  appears in no response DTO or generated TS client. Inventory promotion is driven by the
+  **orthogonal** `ExpiryProfile` facet, not by category. So redefining the enum is low-risk:
+  no branching logic depends on the current values.
+- **Two orthogonal facets, produced in one call.** `ProductClassification(Category, Expiry)`.
+  This spec changes only the `Category` axis. `ExpiryProfile`
+  (`NonPerishable` / `UserEntersFromPackage` / `AiRecommendsShelfLife` + `ShelfLifeDays`) is
+  untouched, and inventory promotion keeps working exactly as today. Aisle and expiry
+  correlate but are not redundant (Frozen pizza = `Frozen` aisle + `UserEntersFromPackage`;
+  pasta = `Pantry` + `NonPerishable`).
+- **The enum is the single source of truth for the model.** `OpenAiItemClassifier`'s strict
+  Structured-Outputs schema derives its `productCategory.enum` from
+  `Enum.GetNames<ProductCategory>()` with `jsonSchemaIsStrict: true` — the model literally
+  cannot return a value outside the enum. Defining the taxonomy = the enum values + one prompt
+  line per value. No hand-edit of the schema skeleton.
+- **Re-classification rollout already exists.** `BackfillProductClassification`
+  (an `IMaintenanceTask`, runs each cold start) scans active list-item names, finds every
+  `Product` below the current `ClassifierVersion`, and enqueues re-classification (throttled to
+  `BackgroundTaskQueue.Capacity` per run, remainder next cold start), plus lazy re-classification
+  on item reference. Bumping the version is the entire trigger — no new rollout code.
+
+## 1. Domain — redefine the enum
+
+`Frigorino.Domain/Products/ProductCategory.cs`: replace the 4 values with **23 aisles + 2
+sentinels**. Keep `Unknown = 0` (stays `default(ProductCategory)` and the safe default) and
+`Other = 1`; aisles take `2..24`.
+
+```
+Unknown = 0               // couldn't classify / nonsense / unrecognized
+Other = 1                 // recognized but not a stocked grocery/household good (a task, a one-off)
+Produce = 2               // Obst & Gemüse
+Bakery = 3                // Backwaren
+Meat = 4                  // Fleisch
+Fish = 5                  // Fisch
+DairyAndEggs = 6          // Milch, Joghurt, Butter, Eier
+Cheese = 7                // Käse
+DeliAndColdCuts = 8       // Wurst, Aufschnitt, Kühltheke
+Frozen = 9                // Tiefkühl
+Pantry = 10               // Nudeln, Reis, Mehl (trockene Grundnahrung)
+CannedGoods = 11          // Konserven / Dosen
+Sauces = 12               // Soßen, Ketchup, Dressings, Passata
+OilsAndVinegar = 13       // Öle & Essig
+Spices = 14               // Gewürze, Salz, Backzutaten
+Cereal = 15               // Müsli, Haferflocken, Cornflakes
+Spreads = 16              // Aufstriche, Marmelade, Nutella, Honig
+Snacks = 17               // Chips, herzhafte Snacks
+Sweets = 18               // Schokolade, Süßigkeiten
+Beverages = 19            // Getränke (alkoholfrei)
+Alcohol = 20              // Bier, Wein, Spirituosen
+HouseholdAndCleaning = 21 // Haushalt & Reinigung
+HealthAndBeauty = 22      // Drogerie & Körperpflege
+Baby = 23                 // Babynahrung, Windeln
+Pet = 24                  // Tierbedarf, Tierfutter
+```
+
+Allocation notes (judgment calls, easy to tweak): `Cheese` and `DeliAndColdCuts` split the old
+deli; `CannedGoods` leaves `Pantry` holding dry staples only; the old `Condiments` becomes three
+aisles (`Sauces`, `OilsAndVinegar`, `Spices`); `Cereal` (Müsli, Haferflocken) and `Spreads`
+(Aufstriche, Marmelade, Nutella) split what was a single breakfast bucket; `Snacks` (savoury) and
+`Sweets` (confectionery) split the old `SnacksAndSweets`; `Baby` and `Pet` are separate aisles.
+
+Update the file's header comment — the old "Food/HouseholdSupply … drives whether Cycle 3
+offers the item for inventory promotion" note is stale (category is unconsumed; expiry drives
+promotion). The new comment states: this is the "what kind / which aisle" facet, orthogonal to
+`ExpiryProfile`; `Unknown = 0` is the safe default and the classification-failure fallback;
+`Other` is a recognized non-shoppable item.
+
+## 2. Infrastructure — classifier prompt + version
+
+`Frigorino.Infrastructure/Services/OpenAiItemClassifier.cs`:
+
+- **Prompt.** Rewrite the `productCategory` block of `SystemPrompt` to describe all 25 values,
+  one short line each with en/de examples (mirroring the existing style). The `expiryHandling`
+  block and the `reasoning`-first ordering are untouched. The strict-output schema `enum`
+  auto-derives from the enum names — no schema-skeleton edit.
+- **Version.** Bump `Version => 2`.
+- **Failure fallback → `Unknown`.** The two fallback sites that currently return
+  `ProductCategory.Other` (empty/refused content at `OpenAiItemClassifier.cs:114`; schema-valid-
+  but-semantically-inconsistent at `:131`) switch to `ProductCategory.Unknown`. Rationale: under the new taxonomy `Other` means
+  "recognized but non-shoppable (a task)", while a *failed* classification is semantically
+  "couldn't classify" = `Unknown`. (The expiry fallback stays `NonPerishable`.)
+
+## 3. Re-classification rollout — no new code
+
+Bumping `Version` 1 → 2 makes every existing `Product` stale (`ClassifierVersion 1 < 2`). The
+existing `BackfillProductClassification` maintenance task re-classifies the whole catalog over
+successive cold starts (capped per run), with lazy re-classification on item reference in
+between. Nothing to build. Old rows keep carrying their version-1 `int` category until
+overwritten; since nothing reads category, the transient state is invisible.
+
+## 4. Cost estimate (the re-classify token budget)
+
+Model: `gpt-5.4-mini` (`appsettings.json` → `Ai:Classifier:Model`).
+
+| Per-call input | Current | After (25 values) |
+|----------------|--------:|------------------:|
+| System prompt | ~300 tok | **~1,020 tok** (`productCategory` block 4 → 25 bilingual lines) |
+| Strict-output schema (counts as input) | ~130 tok | **~240 tok** (25 enum names) |
+| User message (item name) | ~2–6 tok | ~2–6 tok |
+| **Total input / call** | ~440 tok | **~1,270 tok** |
+
+Per-call output: ~60 visible tokens (one-sentence `reasoning` + 3 JSON fields) plus a variable
+model-reasoning-token count (logged via `OutputTokenDetails.ReasoningTokenCount`).
+
+Two factors keep the bulk re-classify cheap:
+
+1. **Prompt caching crosses its threshold.** The static prefix is now ~1,270 tokens —
+   comfortably over OpenAI's 1,024-token caching minimum (the old prompt was *under* it). The
+   system prompt + schema are byte-identical every call, so during a backfill burst nearly all
+   input tokens are cache hits (~10× cheaper). The longer 25-value prompt is close to free in
+   steady state.
+2. **It is N = distinct product names, once.** One call per distinct `(household,
+   normalizedName)` — not per list-item or per request. For the single `stage` client that is
+   tens–low-hundreds of names total. Example: 300 names ≈ ~380k input tokens (mostly cached)
+   + ~20k output, spread across cold starts. Steady-state per-new-name cost is unchanged from
+   today (same one call, slightly longer prompt).
+
+No dollar figure is quoted for `gpt-5.4-mini`; budget as
+`≈ N_names × (~1.3k input + ~80 output) tokens`, most input cached after the first call.
+
+## 5. No migration, no API, no frontend
+
+- **No EF migration.** Category is stored as `int` (EF default); adding CLR enum labels changes
+  no schema. `ProductConfiguration` is unchanged.
+- **No `npm run api` / no frontend.** Category is in no response DTO and no generated client
+  (verified — zero matches under `ClientApp/src/lib`).
+
+## 6. Testing
+
+- **Fixtures using removed values.** Update the `Frigorino.Test` fixtures that name
+  `ProductCategory.Food` / `HouseholdSupply` — `ProductAggregateTests`, `PromoteSuggestionTests`,
+  `ClassifyProductJobTests` — to a surviving value (e.g. `Produce`, `HouseholdAndCleaning`).
+- **Integration stub + steps.** Update `StubItemClassifier` (maps test inputs → categories) and
+  `ClassificationApiSteps` (asserts a category via `Enum.Parse<ProductCategory>`) to the new
+  values.
+- **Rollout trigger.** Ensure a test asserts that a version-1 `Product` is treated as stale and
+  re-classified under version 2 (lock in the version bump). Confirm whether
+  `ProductClassificationGapsTests` / `ClassifyProductJobTests` already cover this; add a case if
+  not.
+- **Fallback.** Add/extend a classifier test that a refusal / empty / inconsistent response now
+  yields `ProductCategory.Unknown` (was `Other`).
+- No JS test runner (unchanged).
+
+## 7. Out of scope (the follow-up sorting spec)
+
+The household `SortBlueprint` store, the blueprint editor UI (reusing `@dnd-kit` `SortableList`),
+the per-list "Sort by category" apply action (a bulk re-rank of the unchecked section via the
+fractional-index `Rank`), and any reading of `EffectiveCategory`. This spec only makes the
+category meaningful; nothing consumes it yet.
+
+## Impact / cost
+
+1 enum rewrite · 1 prompt rewrite + `Version` bump · 2 fallback-constant changes · test fixture
+updates. No EF migration, no API regeneration, no frontend, no new rollout code. Re-classify
+token spend is small and self-throttling (see §4).


### PR DESCRIPTION
## Summary
- Replace the coarse `ProductCategory` enum (`Unknown`/`Other`/`Food`/`HouseholdSupply`) with a **23-aisle supermarket taxonomy + 2 sentinels** (25 values, `0..24`). `Unknown=0` stays `default` and the failure fallback; `Other=1` is the recognized-non-shoppable sentinel.
- Rewrite the OpenAI classifier system prompt to describe all 25 values bilingually (en/de); the strict-output schema auto-derives its enum from `Enum.GetNames<ProductCategory>()`, so no schema hand-edit.
- Bump `OpenAiItemClassifier.Version` 1 → 2, which makes every existing `Product` stale; the existing `BackfillProductClassification` maintenance task re-classifies the referenced catalog over cold starts (no new rollout code).
- Switch the two classification-failure fallbacks from `ProductCategory.Other` to `ProductCategory.Unknown` (a *failed* classification is "couldn't classify" = Unknown, not "recognized non-shoppable" = Other). Expiry fallback stays `NonPerishable`.

This is the prerequisite first slice of the larger "AI-assisted list sorting (category blueprints)" idea. Category is currently classified-but-unconsumed, so this is low-risk: no feature, DTO, or generated client reads it. The blueprint store / editor / per-list apply action are a deliberate **follow-up spec, out of scope**.

**Backend-only:** no EF migration (enum stored as `int`), no `npm run api` / OpenAPI regeneration, no frontend change.

Spec: `docs/superpowers/specs/2026-06-12-aisle-product-taxonomy-design.md`
Plan: `docs/superpowers/plans/2026-06-12-aisle-product-taxonomy.md`

## Test Plan
- [x] `dotnet build Application/Frigorino.sln` — 0 warnings, 0 errors
- [x] `dotnet test Application/Frigorino.sln` — 444 unit + 131 integration green (incl. updated `Classification.Api` / `Extraction.Api` feature scenarios asserting `DairyAndEggs` / `Pantry` / `Other` via the stub)
- [x] `git status` clean — no `openapi.json` / generated-client drift
- [x] `docker build -f Application/Dockerfile` — passes
- [x] Holistic review (opus): SHIP — prompt↔enum names byte-identical, both fallbacks → Unknown, no missed consumers, German chars intact

## Note for the follow-up sorting spec
Orphaned `Product` rows (name no longer on any active list) are never re-classified by the backfill and never purged, so they retain a v1 category `int` reinterpreted under the new enum. Dormant today (nothing reads category). When a consumer is added, gate category reads on `ClassifierVersion == current` or add an orphan-sweep.