### PR TITLE
docs(bugs): report missing human-readable expiry text for far-future dates

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -69,3 +69,16 @@ Places to check: the calendar view's item ordering — likely a sort comparator 
 the expiry date that needs its direction reversed (ascending by expiry date so
 nearest-due is first). Verify whether any already-expired items belong above or
 below upcoming ones once the order is corrected.
+
+## Blueprint list items lack visual separation
+
+Reported by users: items in the blueprint list are not visually separated from
+one another, making the list hard to scan. They should match the look and feel
+of the list/inventory views, where each item sits in its own box/card. The fix
+is a styling alignment — give blueprint items the same boxed/card treatment used
+elsewhere. Investigation deferred.
+
+Places to check: the blueprint list rendering vs. the list/inventory item
+components. Prefer reusing the existing shared item card/surface (per the theme,
+`<Card>` / `<Paper variant="outlined">` rather than a hand-rolled `<Box>`) so the
+separation is consistent rather than re-implemented for blueprints.

--- a/BUGS.md
+++ b/BUGS.md
@@ -82,3 +82,19 @@ Places to check: the blueprint list rendering vs. the list/inventory item
 components. Prefer reusing the existing shared item card/surface (per the theme,
 `<Card>` / `<Paper variant="outlined">` rather than a hand-rolled `<Box>`) so the
 separation is consistent rather than re-implemented for blueprints.
+
+## Flaky integration tests — known undo-toast timing flake
+
+The integration suite has a known intermittent failure around the undo-delete
+toast: the test interacts with the toast in a window where its auto-dismiss
+timer can swallow the action, so the run flakes depending on timing. The ask is
+to remove (or otherwise stabilise) the flaky test(s) so the suite is reliable.
+Investigation deferred.
+
+Places to check: `Frigorino.IntegrationTests/Shared/ToastSteps.cs` and the
+undo-delete-toast scenarios that use it. Git history shows this area has been
+deflaked more than once (e.g. "test: deflake undo-delete-toast integration
+tests"), so it is recurring — before simply deleting, confirm whether the flake
+is the toast's auto-dismiss race again and decide between removing the test
+versus pinning the timer (hover-to-hold) so coverage is kept without the
+flakiness.

--- a/BUGS.md
+++ b/BUGS.md
@@ -55,3 +55,17 @@ truncation on the title, or the actions lacking `flex-shrink: 0`). Confirm
 whether this is one shared row/header component reused by both lists and
 inventories or duplicated per surface, then decide between truncating (ellipsis)
 vs. wrapping the title while keeping the actions pinned and reachable.
+
+## Calendar view sorts by expiry in the wrong direction
+
+Reported by users: in the calendar view, items appear to be ordered with the
+furthest-away expiry first; the expected behaviour is the reverse — items with
+the soonest (lowest) expiration should sit at the top, so the most urgent items
+are seen first. The reporter is not fully certain of the current direction
+("I think it's the other way round"), so the first step is to confirm the
+existing sort order before flipping it. Investigation deferred.
+
+Places to check: the calendar view's item ordering — likely a sort comparator on
+the expiry date that needs its direction reversed (ascending by expiry date so
+nearest-due is first). Verify whether any already-expired items belong above or
+below upcoming ones once the order is corrected.

--- a/BUGS.md
+++ b/BUGS.md
@@ -26,3 +26,18 @@ should carry the target household id and switch the active household to it on
 open (or the inventory route should detect the mismatch and switch) before
 issuing the scoped query. Root cause is the implicit household-context model —
 see "Household context is implicit (LastActiveHouseholdId)…" in `TECH_DEBT.md`.
+
+## Human-readable expiry text missing when expiry is more than ~1 month away
+
+Reported by users: the relative-time label (e.g. "1 month", "1 week", "in 3
+days") is blank when an item's expiry date is far enough in the future —
+roughly beyond a month. Closer expiries render their text fine, so the relative
+formatting appears to drop out past some upper bound rather than failing
+everywhere. Investigation deferred.
+
+Places to check (the relative-expiry label is rendered in more than one spot):
+inventory list/cards, the promote-to-inventory sheet, and any other surface
+that shows an expiry countdown. Confirm whether the gap is in a shared
+relative-time formatter (single root cause across all surfaces) or duplicated
+per-surface logic, then reproduce with a far-future expiry to pin the threshold
+before fixing.

--- a/BUGS.md
+++ b/BUGS.md
@@ -41,3 +41,17 @@ that shows an expiry countdown. Confirm whether the gap is in a shared
 relative-time formatter (single root cause across all surfaces) or duplicated
 per-surface logic, then reproduce with a far-future expiry to pin the threshold
 before fixing.
+
+## Long list/inventory titles overflow and push the action buttons off-screen
+
+Reported by users: when a list or inventory has a long title, the title text
+does not wrap or truncate within its row — it expands the layout and shoves the
+trailing action buttons (e.g. edit/delete/overflow menu) off the visible screen,
+making them unreachable. Investigation deferred.
+
+Places to check: the list/inventory row or card header where the title sits
+alongside the action buttons (likely a flex row missing `min-width: 0` /
+truncation on the title, or the actions lacking `flex-shrink: 0`). Confirm
+whether this is one shared row/header component reused by both lists and
+inventories or duplicated per surface, then decide between truncating (ellipsis)
+vs. wrapping the title while keeping the actions pinned and reachable.


### PR DESCRIPTION
## Summary

Documents a user-reported bug in `BUGS.md`. No code change — investigation/fix deferred.

**Bug:** the relative-time expiry label ("1 month", "1 week", "in 3 days") is blank when an item's expiry is more than ~1 month out. Closer expiries render fine, so the formatting drops out past an upper bound.

**Places to check (noted in the entry):** inventory list/cards, the promote-to-inventory sheet, and any other expiry-countdown surface — confirm whether it's a shared formatter (single root cause) or duplicated per-surface logic before fixing.

Per request: documenting only; investigation will be done later.