### PR TITLE
test: disable flaky undo-delete-toast integration scenarios

### DIFF
--- a/Application/Frigorino.IntegrationTests/Slices/Inventories/InventoryItems.feature
+++ b/Application/Frigorino.IntegrationTests/Slices/Inventories/InventoryItems.feature
@@ -39,6 +39,9 @@ Feature: Inventory Items
     And I click delete from the inventory item menu
     Then "Flour" no longer appears in the inventory
 
+  # Ignored: recurring timing flake on the undo-delete toast (sonner auto-dismiss
+  # race). The hover-to-pin mitigation in ToastSteps reduced but did not eliminate it.
+  @ignore
   Scenario: Undo restores a deleted inventory item via the toast
     Given there is an inventory named "Pantry" with item "Flour"
     When I open the inventory "Pantry"

--- a/Application/Frigorino.IntegrationTests/Slices/Lists/ListItems.feature
+++ b/Application/Frigorino.IntegrationTests/Slices/Lists/ListItems.feature
@@ -47,6 +47,9 @@ Feature: List Items
     And I toggle "Milk" as done
     Then the unchecked items appear in order: "Bread, Milk"
 
+  # Ignored: recurring timing flake on the undo-delete toast (sonner auto-dismiss
+  # race). The hover-to-pin mitigation in ToastSteps reduced but did not eliminate it.
+  @ignore
   Scenario: Undo restores a deleted list item via the toast
     Given there is a list named "Weekly Groceries" with item "Milk"
     When I open the list "Weekly Groceries"

--- a/BUGS.md
+++ b/BUGS.md
@@ -82,19 +82,3 @@ Places to check: the blueprint list rendering vs. the list/inventory item
 components. Prefer reusing the existing shared item card/surface (per the theme,
 `<Card>` / `<Paper variant="outlined">` rather than a hand-rolled `<Box>`) so the
 separation is consistent rather than re-implemented for blueprints.
-
-## Flaky integration tests — known undo-toast timing flake
-
-The integration suite has a known intermittent failure around the undo-delete
-toast: the test interacts with the toast in a window where its auto-dismiss
-timer can swallow the action, so the run flakes depending on timing. The ask is
-to remove (or otherwise stabilise) the flaky test(s) so the suite is reliable.
-Investigation deferred.
-
-Places to check: `Frigorino.IntegrationTests/Shared/ToastSteps.cs` and the
-undo-delete-toast scenarios that use it. Git history shows this area has been
-deflaked more than once (e.g. "test: deflake undo-delete-toast integration
-tests"), so it is recurring — before simply deleting, confirm whether the flake
-is the toast's auto-dismiss race again and decide between removing the test
-versus pinning the timer (hover-to-hold) so coverage is kept without the
-flakiness.


### PR DESCRIPTION
## What

Tags both undo-delete-toast integration scenarios with `@ignore` so they no longer run:
- `Slices/Lists/ListItems.feature` → *Undo restores a deleted list item via the toast*
- `Slices/Inventories/InventoryItems.feature` → *Undo restores a deleted inventory item via the toast*

Also removes the corresponding tracking entry from `BUGS.md`.

## Why

These two scenarios (which share `Shared/ToastSteps.cs`) intermittently fail on a sonner auto-dismiss race: the toast's 5s timer can disable the undo button's `pointer-events` mid-dismiss, so the click is silently swallowed, the `/restore` POST never fires, and the response wait hangs the full 30s timeout. A prior hover-to-pin mitigation in `ToastSteps` (already on stage) reduced but did not eliminate the flake — it recurred.

Per Reqnroll, `@ignore` generates a skipped test method, so the scenarios are **kept, not deleted**. `ToastSteps.cs` is left in place (still referenced) so the scenarios can be re-enabled later if the underlying race is fixed.

## Verification

- `dotnet build Application/Frigorino.IntegrationTests` succeeds (0 errors).
- `@ignore` confirmed present in both generated Gherkin pickles, so the tagged scenarios compile to skipped tests.