### PR TITLE
fix: long titles no longer push header actions off-screen

### DIFF
--- a/Application/Frigorino.IntegrationTests/Slices/Inventories/InventorySearchSteps.cs
+++ b/Application/Frigorino.IntegrationTests/Slices/Inventories/InventorySearchSteps.cs
@@ -6,6 +6,7 @@ public class InventorySearchSteps(ScenarioContextHolder ctx)
     [When("I open the inventory search")]
     public async Task WhenIOpenTheInventorySearch()
     {
+        await ctx.Page.GetByTestId("inventory-header-menu-toggle").ClickAsync();
         await ctx.Page.GetByTestId("inventory-search-button").ClickAsync();
     }
 

--- a/Application/Frigorino.IntegrationTests/Slices/Lists/ListItemSteps.cs
+++ b/Application/Frigorino.IntegrationTests/Slices/Lists/ListItemSteps.cs
@@ -75,7 +75,14 @@ public class ListItemSteps(ScenarioContextHolder ctx, TestApiClient api)
     [When("I enable drag handles")]
     public async Task WhenIEnableDragHandles()
     {
+        await ctx.Page.GetByTestId("list-header-menu-toggle").ClickAsync();
         await ctx.Page.GetByTestId("list-toggle-drag-handles").ClickAsync();
+        // The overflow menu's invisible backdrop covers the viewport during its close
+        // transition. The "I drag" step dispatches raw Mouse events (no actionability
+        // check), so a lingering backdrop would swallow the mouse-down and dnd-kit would
+        // never activate. Wait for the backdrop to detach before continuing.
+        await ctx.Page.Locator(".MuiBackdrop-root")
+            .WaitForAsync(new() { State = WaitForSelectorState.Detached });
         // Wait for at least one drag handle to render so the next "I drag" step doesn't race
         // the toggle re-render.
         await ctx.Page.Locator("[data-testid^='drag-handle-item-']").First.WaitForAsync();

--- a/Application/Frigorino.IntegrationTests/Slices/Lists/ListSearchSteps.cs
+++ b/Application/Frigorino.IntegrationTests/Slices/Lists/ListSearchSteps.cs
@@ -18,6 +18,7 @@ public class ListSearchSteps(ScenarioContextHolder ctx, TestApiClient api)
     [When("I open the list search")]
     public async Task WhenIOpenTheListSearch()
     {
+        await ctx.Page.GetByTestId("list-header-menu-toggle").ClickAsync();
         await ctx.Page.GetByTestId("list-search-button").ClickAsync();
     }
 

--- a/Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
+++ b/Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
@@ -114,6 +114,10 @@
         "removeFromHousehold": "Aus dem Haushalt entfernen"
     },
     "inventory": {
+        "sortOrder": "Sortierung",
+        "sortManual": "Manuelle Reihenfolge",
+        "sortExpiryAsc": "Bald ablaufende zuerst",
+        "sortExpiryDesc": "Spät ablaufende zuerst",
         "createInventory": "Vorrat erstellen",
         "createNewInventory": "Neuen Vorrat erstellen",
         "inventoryName": "Vorratsname",
@@ -160,6 +164,7 @@
         }
     },
     "lists": {
+        "reorderItems": "Einträge umsortieren",
         "createList": "Liste erstellen",
         "editList": "Liste bearbeiten",
         "deleteList": "Liste löschen",

--- a/Application/Frigorino.Web/ClientApp/public/locales/en/translation.json
+++ b/Application/Frigorino.Web/ClientApp/public/locales/en/translation.json
@@ -114,6 +114,10 @@
         "removeFromHousehold": "Remove from household"
     },
     "inventory": {
+        "sortOrder": "Sort order",
+        "sortManual": "Manual order",
+        "sortExpiryAsc": "Soonest expiry first",
+        "sortExpiryDesc": "Latest expiry first",
         "createInventory": "Create inventory",
         "createNewInventory": "Create new inventory",
         "inventoryName": "Inventory name",
@@ -160,6 +164,7 @@
         }
     },
     "lists": {
+        "reorderItems": "Reorder items",
         "createList": "Create list",
         "editList": "Edit list",
         "deleteList": "Delete list",

--- a/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
@@ -98,7 +98,7 @@ export const PageHeadActionBar = memo(
                     <Box
                         sx={{
                             display: "flex",
-                            alignItems: "flex-start",
+                            alignItems: "center",
                             gap: 2,
                         }}
                     >
@@ -123,7 +123,13 @@ export const PageHeadActionBar = memo(
                                 <SectionIcon />
                             </Box>
                         )}
-                        <Box sx={{ flex: 1, minWidth: 0, wordBreak: "break-word" }}>
+                        <Box
+                            sx={{
+                                flex: 1,
+                                minWidth: 0,
+                                wordBreak: "break-word",
+                            }}
+                        >
                             <Typography
                                 variant="h5"
                                 component="h1"

--- a/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
@@ -98,11 +98,14 @@ export const PageHeadActionBar = memo(
                     <Box
                         sx={{
                             display: "flex",
-                            alignItems: "center",
+                            alignItems: "flex-start",
                             gap: 2,
                         }}
                     >
-                        <IconButton onClick={handleBack} sx={{ p: 1 }}>
+                        <IconButton
+                            onClick={handleBack}
+                            sx={{ p: 1, flexShrink: 0 }}
+                        >
                             <ArrowBack />
                         </IconButton>
                         {SectionIcon && (
@@ -120,7 +123,7 @@ export const PageHeadActionBar = memo(
                                 <SectionIcon />
                             </Box>
                         )}
-                        <Box sx={{ flex: 1 }}>
+                        <Box sx={{ flex: 1, minWidth: 0, wordBreak: "break-word" }}>
                             <Typography
                                 variant="h5"
                                 component="h1"
@@ -140,7 +143,14 @@ export const PageHeadActionBar = memo(
                                 </Typography>
                             )}
                         </Box>
-                        <Box sx={{ display: "flex", gap: 1, ml: "auto" }}>
+                        <Box
+                            sx={{
+                                display: "flex",
+                                gap: 1,
+                                ml: "auto",
+                                flexShrink: 0,
+                            }}
+                        >
                             {directActions.map((action, index) => (
                                 <IconButton
                                     key={index}

--- a/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
@@ -133,7 +133,7 @@ export const PageHeadActionBar = memo(
                             <Typography
                                 variant="h5"
                                 component="h1"
-                                sx={{ fontWeight: 600, mb: 0.5 }}
+                                sx={{ fontWeight: 600, mb: subtitle ? 0.5 : 0 }}
                             >
                                 {title}
                             </Typography>

--- a/Application/Frigorino.Web/ClientApp/src/features/blueprints/pages/BlueprintViewPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/blueprints/pages/BlueprintViewPage.tsx
@@ -158,9 +158,11 @@ export const BlueprintViewPage = () => {
                 title={blueprint.name}
                 section="blueprints"
                 maxWidth="md"
-                directActions={[
+                directActions={[]}
+                menuActions={[
                     {
-                        icon: <Edit />,
+                        text: t("common.edit"),
+                        icon: <Edit fontSize="small" />,
                         onClick: () =>
                             navigate({
                                 to: "/household/blueprints/$blueprintId/edit",
@@ -171,7 +173,7 @@ export const BlueprintViewPage = () => {
                         testId: "blueprint-edit-title",
                     },
                 ]}
-                menuActions={[]}
+                menuButtonTestId="blueprint-header-menu-toggle"
             />
             <Container maxWidth="md" sx={pageContainerSx}>
                 <BlueprintArranger

--- a/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryViewPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryViewPage.tsx
@@ -130,12 +130,29 @@ export const InventoryViewPage = () => {
     const getSortModeIcon = (mode: SortMode) => {
         switch (mode) {
             case "expiryDateAsc":
-                return <Schedule />;
+                return <Schedule fontSize="small" />;
             case "expiryDateDesc":
-                return <Schedule style={{ transform: "scaleY(-1)" }} />;
+                return (
+                    <Schedule
+                        fontSize="small"
+                        style={{ transform: "scaleY(-1)" }}
+                    />
+                );
             case "custom":
             default:
-                return <DragIndicator />;
+                return <DragIndicator fontSize="small" />;
+        }
+    };
+
+    const getSortModeLabel = (mode: SortMode) => {
+        switch (mode) {
+            case "expiryDateAsc":
+                return t("inventory.sortExpiryAsc");
+            case "expiryDateDesc":
+                return t("inventory.sortExpiryDesc");
+            case "custom":
+            default:
+                return t("inventory.sortManual");
         }
     };
 
@@ -198,16 +215,28 @@ export const InventoryViewPage = () => {
         );
     }
 
-    const directActions = [
-        { icon: <Edit />, onClick: handleEdit },
-        { icon: getSortModeIcon(sortMode), onClick: handleToggleSortMode },
+    const directActions: HeadNavigationAction[] = [];
+    const menuActions: HeadNavigationAction[] = [
         {
-            icon: <Search />,
+            text: t("common.edit"),
+            icon: <Edit fontSize="small" />,
+            onClick: handleEdit,
+            testId: "inventory-edit-button",
+        },
+        {
+            text: t("inventory.sortOrder"),
+            secondaryText: getSortModeLabel(sortMode),
+            icon: getSortModeIcon(sortMode),
+            onClick: handleToggleSortMode,
+            testId: "inventory-sort-toggle",
+        },
+        {
+            text: t("common.search"),
+            icon: <Search fontSize="small" />,
             onClick: handleToggleSearch,
             testId: "inventory-search-button",
         },
     ];
-    const menuActions: HeadNavigationAction[] = [];
 
     return (
         <Box
@@ -224,6 +253,7 @@ export const InventoryViewPage = () => {
                 section="inventory"
                 directActions={directActions}
                 menuActions={menuActions}
+                menuButtonTestId="inventory-header-menu-toggle"
             />
 
             <SearchInputRow

--- a/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListViewPage.tsx
+++ b/Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListViewPage.tsx
@@ -303,20 +303,26 @@ export const ListViewPage = () => {
         );
     }
 
-    const directActions = [
-        { icon: <Edit />, onClick: handleEdit },
+    const directActions: HeadNavigationAction[] = [];
+    const menuActions: HeadNavigationAction[] = [
         {
-            icon: <DragHandle />,
+            text: t("common.edit"),
+            icon: <Edit fontSize="small" />,
+            onClick: handleEdit,
+            testId: "list-edit-button",
+        },
+        {
+            text: t("lists.reorderItems"),
+            icon: <DragHandle fontSize="small" />,
             onClick: handleToggleDragHandles,
             testId: "list-toggle-drag-handles",
         },
         {
-            icon: <Search />,
+            text: t("common.search"),
+            icon: <Search fontSize="small" />,
             onClick: handleToggleSearch,
             testId: "list-search-button",
         },
-    ];
-    const menuActions: HeadNavigationAction[] = [
         {
             text: t("blueprints.sortByCategory"),
             icon: <Sort fontSize="small" />,
@@ -340,6 +346,7 @@ export const ListViewPage = () => {
                 section="lists"
                 directActions={directActions}
                 menuActions={menuActions}
+                menuButtonTestId="list-header-menu-toggle"
             />
 
             <SearchInputRow

--- a/BUGS.md
+++ b/BUGS.md
@@ -27,20 +27,6 @@ open (or the inventory route should detect the mismatch and switch) before
 issuing the scoped query. Root cause is the implicit household-context model —
 see "Household context is implicit (LastActiveHouseholdId)…" in `TECH_DEBT.md`.
 
-## Long list/inventory titles overflow and push the action buttons off-screen
-
-Reported by users: when a list or inventory has a long title, the title text
-does not wrap or truncate within its row — it expands the layout and shoves the
-trailing action buttons (e.g. edit/delete/overflow menu) off the visible screen,
-making them unreachable. Investigation deferred.
-
-Places to check: the list/inventory row or card header where the title sits
-alongside the action buttons (likely a flex row missing `min-width: 0` /
-truncation on the title, or the actions lacking `flex-shrink: 0`). Confirm
-whether this is one shared row/header component reused by both lists and
-inventories or duplicated per surface, then decide between truncating (ellipsis)
-vs. wrapping the title while keeping the actions pinned and reachable.
-
 ## Calendar view sorts by expiry in the wrong direction
 
 Reported by users: in the calendar view, items appear to be ordered with the

--- a/docs/superpowers/plans/2026-06-13-header-title-overflow.md
+++ b/docs/superpowers/plans/2026-06-13-header-title-overflow.md
@@ -1,0 +1,535 @@
+# Long-title Header Overflow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop long list/inventory/blueprint/household titles from pushing the header action buttons off-screen, and move the detail/view pages' actions into the `⋮` overflow menu so the header stays compact and scalable.
+
+**Architecture:** One shared header component, `PageHeadActionBar`, gets a universal overflow-safety fix (title `min-width:0` + wrap, actions `flex-shrink:0`, row top-aligned). On top of that, the three *view* pages (inventory, list, blueprint) relocate their direct action buttons into the existing `⋮` menu (set `directActions={[]}`, populate `menuActions` with labels). Overview/edit/settings pages are unchanged. Three integration-test steps that clicked relocated buttons directly are updated to open the header menu first.
+
+**Tech Stack:** React 19 + MUI v6 + TanStack Router (SPA), i18next (en/de), Reqnroll + Playwright integration tests.
+
+**Branch:** `fix/header-title-overflow` (already created off `stage`). Spec: `docs/superpowers/specs/2026-06-13-header-title-overflow-design.md`.
+
+**Conventions to honor (from repo memory/CLAUDE.md):**
+- Frontend verify = `npm run tsc` + `npm run lint` + `npm run prettier` from `Application/Frigorino.Web/ClientApp/`.
+- Integration harness serves the SPA from `ClientApp/build` — run `npm run build` after React edits before running IT.
+- Tests assert on testids / `data-*`, never translated text.
+- No `Co-Authored-By` trailers in commits.
+
+---
+
+### Task 1: Core overflow-safety fix in `PageHeadActionBar`
+
+Pure styling change to the shared header. Makes every page overflow-safe. No API change.
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx`
+
+- [ ] **Step 1: Top-align the header row**
+
+In the header row `Box` (currently lines ~98-104), change `alignItems`:
+
+```tsx
+                    <Box
+                        sx={{
+                            display: "flex",
+                            alignItems: "flex-start",
+                            gap: 2,
+                        }}
+                    >
+```
+
+- [ ] **Step 2: Make the back button non-shrinkable**
+
+The back `IconButton` (currently line ~105):
+
+```tsx
+                        <IconButton
+                            onClick={handleBack}
+                            sx={{ p: 1, flexShrink: 0 }}
+                        >
+                            <ArrowBack />
+                        </IconButton>
+```
+
+- [ ] **Step 3: Let the title shrink and wrap**
+
+The title `Box` (currently line ~123, `sx={{ flex: 1 }}`):
+
+```tsx
+                        <Box sx={{ flex: 1, minWidth: 0, wordBreak: "break-word" }}>
+```
+
+Leave the inner `Typography` as-is — with the parent now allowed to shrink, it wraps by default (no `noWrap`).
+
+- [ ] **Step 4: Pin the actions cluster**
+
+The actions `Box` (currently line ~143, `sx={{ display: "flex", gap: 1, ml: "auto" }}`):
+
+```tsx
+                        <Box sx={{ display: "flex", gap: 1, ml: "auto", flexShrink: 0 }}>
+```
+
+- [ ] **Step 5: Type-check and lint**
+
+Run from `Application/Frigorino.Web/ClientApp/`:
+
+```bash
+npm run tsc && npm run lint
+```
+
+Expected: both pass, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/components/shared/PageHeadActionBar.tsx
+git commit -m "fix: keep header title from pushing actions off-screen"
+```
+
+---
+
+### Task 2: Add i18n keys for the relocated menu actions
+
+New labels needed: an inventory "Sort order" item with per-mode secondary text, and a list "Reorder items" item. Edit/Search/Delete reuse existing `common.*` keys.
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/public/locales/en/translation.json`
+- Modify: `Application/Frigorino.Web/ClientApp/public/locales/de/translation.json`
+
+- [ ] **Step 1: Add English keys**
+
+Into the existing `"inventory"` object in `en/translation.json`, add:
+
+```json
+    "sortOrder": "Sort order",
+    "sortManual": "Manual order",
+    "sortExpiryAsc": "Soonest expiry first",
+    "sortExpiryDesc": "Latest expiry first",
+```
+
+Into the existing `"lists"` object in `en/translation.json`, add:
+
+```json
+    "reorderItems": "Reorder items",
+```
+
+- [ ] **Step 2: Add German keys**
+
+Into the existing `"inventory"` object in `de/translation.json`, add:
+
+```json
+    "sortOrder": "Sortierung",
+    "sortManual": "Manuelle Reihenfolge",
+    "sortExpiryAsc": "Bald ablaufende zuerst",
+    "sortExpiryDesc": "Spät ablaufende zuerst",
+```
+
+Into the existing `"lists"` object in `de/translation.json`, add:
+
+```json
+    "reorderItems": "Einträge umsortieren",
+```
+
+- [ ] **Step 3: Validate JSON**
+
+Run from `Application/Frigorino.Web/ClientApp/`:
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('public/locales/en/translation.json','utf8')); JSON.parse(require('fs').readFileSync('public/locales/de/translation.json','utf8')); console.log('OK')"
+```
+
+Expected: prints `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/public/locales/en/translation.json Application/Frigorino.Web/ClientApp/public/locales/de/translation.json
+git commit -m "i18n: labels for header sort/reorder menu actions"
+```
+
+---
+
+### Task 3: `InventoryViewPage` — move actions into the `⋮` menu
+
+Relocate Edit, Sort (cycle), Search from `directActions` into `menuActions`. Sort keeps its cycle-on-tap behavior and shows the current mode via `secondaryText`. Add a `menuButtonTestId` so the IT can open the menu.
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryViewPage.tsx`
+
+- [ ] **Step 1: Render sort-mode icons at menu size**
+
+Update `getSortModeIcon` (currently lines ~130-140) so its icons match the small menu-item icons:
+
+```tsx
+    const getSortModeIcon = (mode: SortMode) => {
+        switch (mode) {
+            case "expiryDateAsc":
+                return <Schedule fontSize="small" />;
+            case "expiryDateDesc":
+                return (
+                    <Schedule
+                        fontSize="small"
+                        style={{ transform: "scaleY(-1)" }}
+                    />
+                );
+            case "custom":
+            default:
+                return <DragIndicator fontSize="small" />;
+        }
+    };
+```
+
+- [ ] **Step 2: Add a sort-mode label helper**
+
+Add this just below `getSortModeIcon` (uses the keys from Task 2):
+
+```tsx
+    const getSortModeLabel = (mode: SortMode) => {
+        switch (mode) {
+            case "expiryDateAsc":
+                return t("inventory.sortExpiryAsc");
+            case "expiryDateDesc":
+                return t("inventory.sortExpiryDesc");
+            case "custom":
+            default:
+                return t("inventory.sortManual");
+        }
+    };
+```
+
+- [ ] **Step 3: Replace `directActions`/`menuActions`**
+
+Replace the block currently at lines ~201-210 (`const directActions = [...]; const menuActions: HeadNavigationAction[] = [];`) with:
+
+```tsx
+    const directActions: HeadNavigationAction[] = [];
+    const menuActions: HeadNavigationAction[] = [
+        {
+            text: t("common.edit"),
+            icon: <Edit fontSize="small" />,
+            onClick: handleEdit,
+            testId: "inventory-edit-button",
+        },
+        {
+            text: t("inventory.sortOrder"),
+            secondaryText: getSortModeLabel(sortMode),
+            icon: getSortModeIcon(sortMode),
+            onClick: handleToggleSortMode,
+            testId: "inventory-sort-toggle",
+        },
+        {
+            text: t("common.search"),
+            icon: <Search fontSize="small" />,
+            onClick: handleToggleSearch,
+            testId: "inventory-search-button",
+        },
+    ];
+```
+
+- [ ] **Step 4: Pass `directActions={[]}` and a menu testid to the header**
+
+Update the `<PageHeadActionBar>` usage (currently lines ~221-227):
+
+```tsx
+            <PageHeadActionBar
+                title={inventory.name || t("inventory.untitledInventory")}
+                subtitle={inventory.description || undefined}
+                section="inventory"
+                directActions={directActions}
+                menuActions={menuActions}
+                menuButtonTestId="inventory-header-menu-toggle"
+            />
+```
+
+- [ ] **Step 5: Type-check and lint**
+
+Run from `ClientApp/`:
+
+```bash
+npm run tsc && npm run lint
+```
+
+Expected: pass. (`HeadNavigationAction` is already imported in this file.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/features/inventories/pages/InventoryViewPage.tsx
+git commit -m "fix: move inventory header actions into overflow menu"
+```
+
+---
+
+### Task 4: `ListViewPage` — move actions into the `⋮` menu
+
+Relocate Edit, Reorder (drag-handle toggle), Search into `menuActions` alongside the existing "Sort by category". Add a `menuButtonTestId`.
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListViewPage.tsx`
+
+- [ ] **Step 1: Replace `directActions`/`menuActions`**
+
+Replace the block currently at lines ~306-326 with (keep the existing testids; preserve handler references `handleEdit`, `handleToggleDragHandles`, `handleToggleSearch`, `setSortDialogOpen`):
+
+```tsx
+    const directActions: HeadNavigationAction[] = [];
+    const menuActions: HeadNavigationAction[] = [
+        {
+            text: t("common.edit"),
+            icon: <Edit fontSize="small" />,
+            onClick: handleEdit,
+            testId: "list-edit-button",
+        },
+        {
+            text: t("lists.reorderItems"),
+            icon: <DragHandle fontSize="small" />,
+            onClick: handleToggleDragHandles,
+            testId: "list-toggle-drag-handles",
+        },
+        {
+            text: t("common.search"),
+            icon: <Search fontSize="small" />,
+            onClick: handleToggleSearch,
+            testId: "list-search-button",
+        },
+        {
+            text: t("blueprints.sortByCategory"),
+            icon: <Sort fontSize="small" />,
+            onClick: () => setSortDialogOpen(true),
+            testId: "list-sort-by-category",
+        },
+    ];
+```
+
+- [ ] **Step 2: Pass `directActions={[]}` and a menu testid to the header**
+
+Update the `<PageHeadActionBar>` usage (currently lines ~337-343):
+
+```tsx
+            <PageHeadActionBar
+                title={list.name || t("lists.untitledList")}
+                subtitle={list.description || undefined}
+                section="lists"
+                directActions={directActions}
+                menuActions={menuActions}
+                menuButtonTestId="list-header-menu-toggle"
+            />
+```
+
+- [ ] **Step 3: Type-check and lint**
+
+Run from `ClientApp/`:
+
+```bash
+npm run tsc && npm run lint
+```
+
+Expected: pass. (`Edit`, `DragHandle`, `Search`, `Sort`, and `HeadNavigationAction` are already imported in this file.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/features/lists/pages/ListViewPage.tsx
+git commit -m "fix: move list header actions into overflow menu"
+```
+
+---
+
+### Task 5: `BlueprintViewPage` — move Edit into the `⋮` menu
+
+Relocate the single Edit action into the menu and add a `menuButtonTestId`.
+
+**Files:**
+- Modify: `Application/Frigorino.Web/ClientApp/src/features/blueprints/pages/BlueprintViewPage.tsx`
+
+- [ ] **Step 1: Replace the `<PageHeadActionBar>` usage**
+
+Replace the block currently at lines ~157-175 with:
+
+```tsx
+            <PageHeadActionBar
+                title={blueprint.name}
+                section="blueprints"
+                maxWidth="md"
+                directActions={[]}
+                menuActions={[
+                    {
+                        text: t("common.edit"),
+                        icon: <Edit fontSize="small" />,
+                        onClick: () =>
+                            navigate({
+                                to: "/household/blueprints/$blueprintId/edit",
+                                params: {
+                                    blueprintId: blueprint.id.toString(),
+                                },
+                            }),
+                        testId: "blueprint-edit-title",
+                    },
+                ]}
+                menuButtonTestId="blueprint-header-menu-toggle"
+            />
+```
+
+- [ ] **Step 2: Type-check and lint**
+
+Run from `ClientApp/`:
+
+```bash
+npm run tsc && npm run lint
+```
+
+Expected: pass. (`Edit` is already imported in this file.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Application/Frigorino.Web/ClientApp/src/features/blueprints/pages/BlueprintViewPage.tsx
+git commit -m "fix: move blueprint header edit into overflow menu"
+```
+
+---
+
+### Task 6: Update integration-test steps to open the header menu first
+
+Three existing steps click a now-relocated action directly. Each must open the header `⋮` menu (the testids added in Tasks 3-4) before clicking the menu item. MUI renders the menu in a portal; clicking the same testid still works once the menu is open.
+
+**Files:**
+- Modify: `Application/Frigorino.IntegrationTests/Slices/Inventories/InventorySearchSteps.cs`
+- Modify: `Application/Frigorino.IntegrationTests/Slices/Lists/ListSearchSteps.cs`
+- Modify: `Application/Frigorino.IntegrationTests/Slices/Lists/ListItemSteps.cs`
+
+- [ ] **Step 1: Rebuild the SPA so the IT harness serves the new markup**
+
+The integration harness serves `ClientApp/build`, not live source. Run from `Application/Frigorino.Web/ClientApp/`:
+
+```bash
+npm run build
+```
+
+Expected: `tsc -b && vite build` completes, writes `ClientApp/build`.
+
+- [ ] **Step 2: Open the inventory menu before clicking Search**
+
+In `InventorySearchSteps.cs`, replace the body of `WhenIOpenTheInventorySearch` (currently line 9):
+
+```csharp
+    [When("I open the inventory search")]
+    public async Task WhenIOpenTheInventorySearch()
+    {
+        await ctx.Page.GetByTestId("inventory-header-menu-toggle").ClickAsync();
+        await ctx.Page.GetByTestId("inventory-search-button").ClickAsync();
+    }
+```
+
+- [ ] **Step 3: Open the list menu before clicking Search**
+
+In `ListSearchSteps.cs`, replace the body of `WhenIOpenTheListSearch` (currently line 21):
+
+```csharp
+    [When("I open the list search")]
+    public async Task WhenIOpenTheListSearch()
+    {
+        await ctx.Page.GetByTestId("list-header-menu-toggle").ClickAsync();
+        await ctx.Page.GetByTestId("list-search-button").ClickAsync();
+    }
+```
+
+- [ ] **Step 4: Open the list menu before toggling drag handles**
+
+In `ListItemSteps.cs`, update `WhenIEnableDragHandles` (currently lines 75-82):
+
+```csharp
+    [When("I enable drag handles")]
+    public async Task WhenIEnableDragHandles()
+    {
+        await ctx.Page.GetByTestId("list-header-menu-toggle").ClickAsync();
+        await ctx.Page.GetByTestId("list-toggle-drag-handles").ClickAsync();
+        // Wait for at least one drag handle to render so the next "I drag" step doesn't race
+        // the toggle re-render.
+        await ctx.Page.Locator("[data-testid^='drag-handle-item-']").First.WaitForAsync();
+    }
+```
+
+- [ ] **Step 5: Run the inventory + list integration scenarios**
+
+Run the affected feature areas first for a fast signal:
+
+```bash
+dotnet test Application/Frigorino.IntegrationTests --filter "FullyQualifiedName~Inventor|FullyQualifiedName~List"
+```
+
+Expected: PASS. Confirm the run actually executed scenarios (check the "Passed!" total is non-zero) — per repo note, a too-narrow filter can report green without running anything.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Application/Frigorino.IntegrationTests/Slices/Inventories/InventorySearchSteps.cs Application/Frigorino.IntegrationTests/Slices/Lists/ListSearchSteps.cs Application/Frigorino.IntegrationTests/Slices/Lists/ListItemSteps.cs
+git commit -m "test: open header menu before clicking relocated actions"
+```
+
+---
+
+### Task 7: Manual verification, BUGS.md cleanup, full verify
+
+CSS wrap behavior is verified manually in the running app (Playwright cannot reliably assert horizontal off-screen overflow — a manual browser check is the net). Then remove the bug entry and run the full gate.
+
+**Files:**
+- Modify: `BUGS.md`
+
+- [ ] **Step 1: Bring up the dev stack (if not already up)**
+
+```bash
+powershell -ExecutionPolicy Bypass -File scripts/dev-up.ps1
+```
+
+Read `.dev/stack.json` for the Vite URL.
+
+- [ ] **Step 2: Manually verify in the browser (phone width ~390px)**
+
+Using the running SPA (seed via the UI or API — dev data is disposable):
+- Give a list (and an inventory) a very long name (e.g. "Weekly Groceries For The Whole Extended Family"). Open it.
+  - Expected: the title **wraps** to multiple lines; the `⋮` button stays on-screen and is clickable; opening it shows Edit / Reorder (lists) / Search / Sort.
+- Open an inventory with a long name.
+  - Expected: title wraps; `⋮` opens Edit / Sort order (with current mode as secondary text) / Search.
+- Check a **short** title on each.
+  - Expected: header looks correct, back button + section icon + `⋮` aligned to the title's first line.
+- Confirm an **overview** page (Lists / Inventories) is unchanged — the primary `+` is still a visible button.
+
+- [ ] **Step 3: Remove the bug entry from BUGS.md**
+
+Delete the section `## Long list/inventory titles overflow and push the action buttons off-screen` and its body (the paragraphs through "...vs. wrapping the title while keeping the actions pinned and reachable.").
+
+- [ ] **Step 4: Frontend verify**
+
+Run from `Application/Frigorino.Web/ClientApp/`:
+
+```bash
+npm run tsc && npm run lint && npm run prettier
+```
+
+Expected: all pass / clean.
+
+- [ ] **Step 5: Full solution test gate**
+
+```bash
+dotnet test Application/Frigorino.sln
+```
+
+Expected: PASS (runs `Frigorino.Test` + `Frigorino.IntegrationTests`). If the backend dev server is holding locked `bin/Debug` DLLs, tear down the dev stack first (`scripts/dev-down.ps1`) and re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add BUGS.md
+git commit -m "docs(bugs): remove fixed long-title header overflow entry"
+```
+
+---
+
+## Notes for the implementer
+
+- **Do not** touch `ListsPage`, `InventoriesPage`, `BlueprintsPage`, `ExpiryCalendarPage` (overview pages keep their `+`/settings buttons), nor the edit/settings pages (already menu-only). They inherit the Task 1 fix for free.
+- **Summary cards** (`ListSummaryCard`/`InventorySummaryCard`/`BlueprintSummaryCard`) and the dashboard rows are a separate, deferred bug — out of scope here.
+- The `⋮` menu only renders when `menuActions.length > 0` (see `PageHeadActionBar.tsx` line ~158). After Tasks 3-5 every view page has menu actions, so the toggle is always present.
+- Keep all existing testids exactly as written so unmodified IT steps keep matching; only the *interaction path* (open menu first) changes.

--- a/docs/superpowers/specs/2026-06-13-header-title-overflow-design.md
+++ b/docs/superpowers/specs/2026-06-13-header-title-overflow-design.md
@@ -1,0 +1,136 @@
+# Long-title header overflow — design
+
+**Date:** 2026-06-13
+**Branch:** `fix/header-title-overflow`
+**Bug:** "Long list/inventory titles overflow and push the action buttons off-screen" (BUGS.md)
+
+## Problem
+
+On detail pages, a long list/inventory/blueprint/household title does not wrap or
+truncate. In `PageHeadActionBar` the title `Box` has `flex: 1` but **no
+`min-width: 0`**, so a long `<h5>` cannot shrink below its content width — it
+expands the flex row and pushes the trailing action buttons (edit / sort /
+search / overflow) past the right edge of the viewport, where they are
+unreachable.
+
+`PageHeadActionBar` (`src/components/shared/PageHeadActionBar.tsx`) is the single
+header component shared by **12 pages**. Only some of them have long,
+user-content titles; the overview pages have short static titles.
+
+## Decisions (from brainstorming)
+
+- **Title behaviour:** wrap to multiple lines, never ellipsis-truncate. "If the
+  text still doesn't fit, it grows downward."
+- **Action behaviour on the detail/view pages:** *always in menu* — the header
+  keeps only `back · section-icon · title · ⋮`, and every action lives in the
+  overflow menu. This is the simplest, most scalable shape: adding a future
+  action is just another menu item and the header geometry never changes.
+- **Scope:** `PageHeadActionBar` only. Summary cards (`ListSummaryCard`,
+  `InventorySummaryCard`, `BlueprintSummaryCard`) and the dashboard
+  (`WelcomePage`) rows have the same class of bug but a different structure and
+  are deferred to a separate pass.
+- **Scope split within the shared component:** the *view/detail* pages go
+  always-in-menu; the *overview* pages keep their primary `+` / settings as
+  direct buttons (static titles, no overflow risk, and a visible "create" CTA
+  matters).
+
+## Design
+
+### 1. Core overflow-safety fix — `PageHeadActionBar` (universal)
+
+Applies to every page that uses the component, including those left otherwise
+unchanged (e.g. `ManageHouseholdPage`, whose title is a user-named household).
+
+In the header row (`PageHeadActionBar.tsx` ~lines 98–170):
+
+- **Header row container:** change `alignItems: "center"` → `alignItems: "flex-start"`,
+  so the back button, section icon, and actions pin to the **first line** of the
+  title when it wraps (rather than centering against a tall multi-line block).
+- **Title `Box`** (currently `sx={{ flex: 1 }}`): add `minWidth: 0` and
+  `wordBreak: "break-word"`. `min-width: 0` lets the flex item shrink so the
+  title wraps; `word-break` covers a single very long unbroken token.
+- **Actions `Box`** (currently `sx={{ display: "flex", gap: 1, ml: "auto" }}`):
+  add `flexShrink: 0` so the action cluster keeps its intrinsic width and is
+  never compressed or pushed off-screen.
+- **Back button + section icon:** already fixed-size; the section icon already
+  has `flexShrink: 0`. Add `flexShrink: 0` to the back `IconButton` for symmetry
+  so it can never be squeezed.
+
+Net effect: a long title wraps and increases the header's height; the action
+cluster stays pinned top-right and reachable. This change alone resolves the
+reported bug for all pages.
+
+No public API change in this step; it is pure styling.
+
+### 2. Always-in-menu — the detail/view pages
+
+Move each view page's direct actions into `menuActions` (set
+`directActions={[]}`). Each relocated action gains a `text` label (required for a
+menu item) and keeps its existing `icon`, `onClick`, and `testId` **unchanged**.
+Behaviour of every action is preserved exactly — only its presentation moves from
+an icon button to a menu row.
+
+- **`InventoryViewPage`** (`features/inventories/pages/InventoryViewPage.tsx`):
+  relocate Edit, Sort (the `getSortModeIcon(sortMode)` cycle), Search.
+  - The Sort item keeps its cycle-on-tap `handleToggleSortMode` behaviour and
+    surfaces the current mode via `secondaryText` (e.g. "Manual" / "A→Z"), so the
+    menu row communicates state that the bare icon used to.
+- **`ListViewPage`** (`features/lists/pages/ListViewPage.tsx`):
+  relocate Edit, Reorder (the drag-handle toggle, testid `list-toggle-drag-handles`),
+  Search. The existing "Sort by category" menu item (opens the sort dialog)
+  stays. Suggested order: Edit, Reorder, Search, Sort by category.
+- **`BlueprintViewPage`** (`features/blueprints/pages/BlueprintViewPage.tsx`):
+  relocate the single Edit action.
+- **`ManageHouseholdPage`**: already menu-only (delete). No change beyond the
+  core fix in §1.
+
+Resulting view-page header: `back · section-icon · wrapping-title · ⋮`.
+
+### 3. Unchanged by design
+
+- **Overview pages** — `ListsPage`, `InventoriesPage`, `BlueprintsPage`,
+  `ExpiryCalendarPage`: keep their direct `+` / calendar / settings / search
+  buttons. Static titles, no overflow, and the primary action should stay
+  visible. They still inherit the §1 overflow-safety fix.
+- **Edit pages + Settings** — `ListEditPage`, `InventoryEditPage`,
+  `BlueprintEditPage`, `UserSettingsPage`: already `directActions={[]}`; no
+  change.
+- **Summary cards + dashboard rows:** deferred (separate bug entry).
+
+### 4. i18n
+
+Add the menu-item labels in both `public/locales/en/translation.json` and
+`public/locales/de/translation.json`. Reuse existing keys where present
+(`common.edit`, `common.delete`, and a search label if one already exists);
+add new keys for "reorder items" and the inventory sort-mode labels. Exact key
+names and reuse are determined during implementation by inspecting the existing
+translation files. No hard-coded user-facing strings.
+
+## Testing
+
+- **Unit:** `PageHeadActionBar` is presentational; no new unit tests.
+- **Integration (the real risk):** moving Search / Edit / Reorder from direct
+  buttons into the `⋮` menu changes how they are reached. The testids survive
+  (placed on each `MenuItem`), but every existing Playwright step that clicks a
+  relocated action directly now needs an **"open the header `⋮` menu first"**
+  step. Audit `Frigorino.IntegrationTests` for the affected testids —
+  `inventory-search-button`, `list-search-button`, `list-toggle-drag-handles`,
+  and any edit-from-header steps — and insert the menu-open step before each.
+  Add a focused assertion that a long title wraps without the `⋮` leaving the
+  viewport, asserting on testids only (never translated text).
+- **Manual:** verify in the running dev stack with a deliberately long title on
+  an inventory and a list (title wraps, `⋮` reachable, menu actions work), plus
+  a short title (header still looks right), at phone width.
+
+## Verification
+
+- Frontend: `npm run tsc`, `npm run lint`, `npm run prettier` (from `ClientApp/`).
+- Regenerate API client is **not** needed (no backend/DTO change).
+- Full `dotnet test Application/Frigorino.sln` to run the integration suite after
+  the IT step updates.
+
+## Out of scope / follow-ups
+
+- Summary-card and dashboard title overflow (same bug class, different markup).
+- Any redesign of the inventory sort UX (cycle vs. picker) — behaviour is
+  preserved as-is, only relocated.


### PR DESCRIPTION
## Summary

Fixes the reported bug where a long list/inventory/blueprint title would expand the header row and shove the trailing action buttons off the visible screen, making them unreachable.

Two layers:

- **Universal overflow-safety in the shared `PageHeadActionBar`:** the title flex item gets `min-width: 0` + `word-break: break-word` (so it can shrink and wrap instead of expanding the row), the back button and actions cluster get `flex-shrink: 0` (so they're never compressed or pushed off-screen). The row stays vertically centered, and the title's bottom margin now only applies when a subtitle is present (no stray offset on subtitle-less headers).
- **Always-in-menu for the three view pages** (Inventory, List, Blueprint): their direct action icons now live in the existing `⋮` overflow menu, keeping the header compact and scalable as actions are added. The inventory sort item shows the current mode as secondary text. Overview/edit/settings pages are unchanged.

New i18n keys (en + de) for the sort/reorder menu labels. Three integration-test steps that clicked the relocated buttons directly now open the header menu first; the drag step also waits for the menu's invisible backdrop to detach before its raw-pointer drag.

A long-title header now wraps downward while the `⋮` stays on-screen and reachable.

## Test Plan

- [x] `npm run tsc` + `npm run lint` + `npm run prettier` clean
- [x] Full `dotnet test Application/Frigorino.sln` green — 464 unit + 131 integration (2 known-flaky undo-toast skipped), 0 failures
- [x] Manual browser verify at phone width (390px): long title wraps to multiple lines, `⋮` stays within viewport (no horizontal overflow), menu opens with Edit / Sort (current mode) / Search; short titles stay vertically centered with the icons
- [x] Opus holistic review: no blockers, no should-fixes