### PR TITLE
test(recipes): attachment-flow integration tests

### DIFF
--- a/Application/Frigorino.IntegrationTests/Infrastructure/ScenarioContextHolder.cs
+++ b/Application/Frigorino.IntegrationTests/Infrastructure/ScenarioContextHolder.cs
@@ -14,6 +14,10 @@ public class ScenarioContextHolder
     public Dictionary<string, int> RecipeIds { get; } = new();
     public Dictionary<(string Recipe, string Section), int> RecipeSectionIds { get; } = new();
     public Dictionary<(string Recipe, string Label), int> RecipeLinkIds { get; } = new();
+
+    // Recipe attachments are keyed by caption (unique within a scenario), so a step can resolve the
+    // id it needs without threading the recipe name through every UI interaction.
+    public Dictionary<string, int> RecipeAttachmentIds { get; } = new();
     public IAPIResponse? LastApiResponse { get; set; }
     public IAPIResponse[]? ConcurrentApiResponses { get; set; }
 

--- a/Application/Frigorino.IntegrationTests/Infrastructure/TestApiClient.cs
+++ b/Application/Frigorino.IntegrationTests/Infrastructure/TestApiClient.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 
 namespace Frigorino.IntegrationTests.Infrastructure;
@@ -695,5 +696,82 @@ public class TestApiClient(ScenarioContextHolder ctx)
                 DataObject = new { name, description = (string?)null, servings },
                 Headers = AuthHeaders,
             });
+    }
+
+    // ---- Recipe attachments (multipart upload + byte-serving) ----
+
+    // Minimal PDF bytes — the document path stores the raw bytes as-is (no parsing), so a header +
+    // EOF marker is enough to round-trip and serve back with content-type application/pdf.
+    private static readonly byte[] TinyPdf = Encoding.ASCII.GetBytes(
+        "%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF");
+
+    public Task<IAPIResponse> TryUploadRecipeImageAttachmentAsync(int recipeId, string caption = "", int? householdId = null)
+    {
+        var targetHouseholdId = householdId ?? ctx.HouseholdId;
+        var form = ctx.BrowserContext.APIRequest.CreateFormData();
+        form.Append("file", new FilePayload { Name = "photo.png", MimeType = "image/png", Buffer = TinyPng });
+        form.Append("caption", caption);
+        return ctx.BrowserContext.APIRequest.PostAsync(
+            $"/api/household/{targetHouseholdId}/recipes/{recipeId}/attachments",
+            new APIRequestContextOptions { Headers = AuthHeaders, Multipart = form });
+    }
+
+    public Task<IAPIResponse> TryUploadRecipeDocumentAttachmentAsync(int recipeId, string caption = "", int? householdId = null)
+    {
+        var targetHouseholdId = householdId ?? ctx.HouseholdId;
+        var form = ctx.BrowserContext.APIRequest.CreateFormData();
+        form.Append("file", new FilePayload { Name = "sheet.pdf", MimeType = "application/pdf", Buffer = TinyPdf });
+        form.Append("caption", caption);
+        return ctx.BrowserContext.APIRequest.PostAsync(
+            $"/api/household/{targetHouseholdId}/recipes/{recipeId}/attachments",
+            new APIRequestContextOptions { Headers = AuthHeaders, Multipart = form });
+    }
+
+    public async Task<int> CreateRecipeImageAttachmentAsync(int recipeId, string caption = "")
+    {
+        var response = await TryUploadRecipeImageAttachmentAsync(recipeId, caption);
+        if (!response.Ok)
+        {
+            throw new Exception($"CreateRecipeImageAttachmentAsync failed: {response.Status} {await response.TextAsync()}");
+        }
+
+        var json = await response.JsonAsync();
+        return json!.Value.GetProperty("id").GetInt32();
+    }
+
+    public async Task<int> CreateRecipeDocumentAttachmentAsync(int recipeId, string caption = "")
+    {
+        var response = await TryUploadRecipeDocumentAttachmentAsync(recipeId, caption);
+        if (!response.Ok)
+        {
+            throw new Exception($"CreateRecipeDocumentAttachmentAsync failed: {response.Status} {await response.TextAsync()}");
+        }
+
+        var json = await response.JsonAsync();
+        return json!.Value.GetProperty("id").GetInt32();
+    }
+
+    public Task<IAPIResponse> TryGetRecipeAttachmentsAsync(int recipeId, int? householdId = null)
+    {
+        var targetHouseholdId = householdId ?? ctx.HouseholdId;
+        return ctx.BrowserContext.APIRequest.GetAsync(
+            $"/api/household/{targetHouseholdId}/recipes/{recipeId}/attachments",
+            new APIRequestContextOptions { Headers = AuthHeaders });
+    }
+
+    public Task<IAPIResponse> TryGetRecipeAttachmentFileAsync(int recipeId, int attachmentId, int? householdId = null)
+    {
+        var targetHouseholdId = householdId ?? ctx.HouseholdId;
+        return ctx.BrowserContext.APIRequest.GetAsync(
+            $"/api/household/{targetHouseholdId}/recipes/{recipeId}/attachments/{attachmentId}/file",
+            new APIRequestContextOptions { Headers = AuthHeaders });
+    }
+
+    public Task<IAPIResponse> TryGetRecipeAttachmentThumbnailAsync(int recipeId, int attachmentId, int? householdId = null)
+    {
+        var targetHouseholdId = householdId ?? ctx.HouseholdId;
+        return ctx.BrowserContext.APIRequest.GetAsync(
+            $"/api/household/{targetHouseholdId}/recipes/{recipeId}/attachments/{attachmentId}/thumbnail",
+            new APIRequestContextOptions { Headers = AuthHeaders });
     }
 }

--- a/Application/Frigorino.IntegrationTests/Slices/Recipes/RecipeAttachmentSteps.cs
+++ b/Application/Frigorino.IntegrationTests/Slices/Recipes/RecipeAttachmentSteps.cs
@@ -1,0 +1,264 @@
+namespace Frigorino.IntegrationTests.Slices.Recipes;
+
+[Binding]
+public class RecipeAttachmentSteps
+{
+    private readonly ScenarioContextHolder ctx;
+    private readonly TestApiClient api;
+
+    public RecipeAttachmentSteps(ScenarioContextHolder ctx, TestApiClient api)
+    {
+        this.ctx = ctx;
+        this.api = api;
+    }
+
+    // Same valid 8x8 RGBA PNG used by the media-item steps — the image path re-encodes via Magick.NET,
+    // which validates the IDAT CRC, so the bytes must be a real image.
+    private static readonly byte[] TinyPng = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVR4nGOpCDjxnwEPYGEgAIaHAgCvwgKw2JOr9gAAAABJRU5ErkJggg==");
+
+    // Minimal PDF — the document path stores the raw bytes as-is (no parsing).
+    private static readonly byte[] TinyPdf = System.Text.Encoding.ASCII.GetBytes(
+        "%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF");
+
+    // ---- Seed helpers (API) ----
+
+    [Given("the recipe {string} has an image attachment captioned {string}")]
+    public async Task GivenRecipeHasImageAttachment(string recipeName, string caption)
+    {
+        var recipeId = ctx.RecipeIds[recipeName];
+        ctx.RecipeAttachmentIds[caption] = await api.CreateRecipeImageAttachmentAsync(recipeId, caption);
+    }
+
+    [Given("the recipe {string} has a document attachment captioned {string}")]
+    public async Task GivenRecipeHasDocumentAttachment(string recipeName, string caption)
+    {
+        var recipeId = ctx.RecipeIds[recipeName];
+        ctx.RecipeAttachmentIds[caption] = await api.CreateRecipeDocumentAttachmentAsync(recipeId, caption);
+    }
+
+    // ---- Section expand ----
+
+    [When("I expand the attachments section")]
+    public async Task WhenIExpandTheAttachmentsSection()
+    {
+        // The attachments section persists collapsed by default — expand it (idempotently) so the
+        // upload affordance and attachment rows are interactable.
+        var summary = ctx.Page.GetByTestId("recipe-section-attachments-summary");
+        if (await summary.GetAttributeAsync("aria-expanded") != "true")
+        {
+            await summary.ClickAsync();
+        }
+        await Assertions.Expect(summary).ToHaveAttributeAsync("aria-expanded", "true");
+    }
+
+    // ---- Upload via UI ----
+
+    [When("I attach an image with caption {string}")]
+    public async Task WhenIAttachAnImageWithCaption(string caption)
+    {
+        await ctx.Page.GetByTestId("recipe-add-attachment").ClickAsync();
+        await ctx.Page.GetByTestId("recipe-attachment-photo").ClickAsync();
+        await ctx.Page.GetByTestId("recipe-attachment-file-input").SetInputFilesAsync(new FilePayload
+        {
+            Name = "photo.png",
+            MimeType = "image/png",
+            Buffer = TinyPng,
+        });
+        await Assertions.Expect(ctx.Page.GetByTestId("recipe-attachment-preview-sheet")).ToBeVisibleAsync();
+        await ctx.Page.GetByTestId("recipe-attachment-caption-input").FillAsync(caption);
+        await SendAttachmentAndCaptureIdAsync(caption);
+    }
+
+    [When("I attach a document with caption {string}")]
+    public async Task WhenIAttachADocumentWithCaption(string caption)
+    {
+        await ctx.Page.GetByTestId("recipe-add-attachment").ClickAsync();
+        await ctx.Page.GetByTestId("recipe-attachment-document").ClickAsync();
+        await ctx.Page.GetByTestId("recipe-attachment-document-input").SetInputFilesAsync(new FilePayload
+        {
+            Name = "sheet.pdf",
+            MimeType = "application/pdf",
+            Buffer = TinyPdf,
+        });
+        await Assertions.Expect(ctx.Page.GetByTestId("recipe-attachment-document-preview")).ToBeVisibleAsync();
+        await ctx.Page.GetByTestId("recipe-attachment-caption-input").FillAsync(caption);
+        await SendAttachmentAndCaptureIdAsync(caption);
+    }
+
+    // Clicks Send, awaits the POST 201, and records the new attachment id so later steps can target
+    // its row/tile by testid (the id is part of every attachment testid).
+    private async Task SendAttachmentAndCaptureIdAsync(string caption)
+    {
+        var responseTask = ctx.Page.WaitForResponseAsync(r =>
+            r.Url.Contains("/attachments")
+            && r.Request.Method == "POST"
+            && r.Status == 201);
+        await ctx.Page.GetByTestId("recipe-attachment-send-button").ClickAsync();
+        var response = await responseTask;
+        var json = await response.JsonAsync();
+        ctx.RecipeAttachmentIds[caption] = json!.Value.GetProperty("id").GetInt32();
+    }
+
+    // ---- Caption edit ----
+
+    [When("I edit the attachment captioned {string} to {string}")]
+    public async Task WhenIEditTheAttachmentCaption(string oldCaption, string newCaption)
+    {
+        var id = ctx.RecipeAttachmentIds[oldCaption];
+        await ctx.Page.GetByTestId($"recipe-attachment-{id}-edit").ClickAsync();
+        await Assertions.Expect(ctx.Page.GetByTestId("recipe-attachment-caption-sheet")).ToBeVisibleAsync();
+        await ctx.Page.GetByTestId("recipe-attachment-caption-edit-input").FillAsync(newCaption);
+
+        var responseTask = ctx.Page.WaitForResponseAsync(r =>
+            r.Url.Contains("/attachments/")
+            && r.Request.Method == "PUT"
+            && r.Status == 200);
+        await ctx.Page.GetByTestId("recipe-attachment-caption-save-button").ClickAsync();
+        await responseTask;
+    }
+
+    // ---- Reorder via drag ----
+
+    [When("I drag the attachment captioned {string} above {string}")]
+    public async Task WhenIDragTheAttachmentAbove(string sourceCaption, string targetCaption)
+    {
+        // dnd-kit PointerSensor has activationConstraint { distance: 8 }, so a real drag must move
+        // >8px after mouse-down before activation.
+        var sourceHandle = ctx.Page.GetByTestId($"recipe-link-drag-handle-{ctx.RecipeAttachmentIds[sourceCaption]}");
+        var targetHandle = ctx.Page.GetByTestId($"recipe-link-drag-handle-{ctx.RecipeAttachmentIds[targetCaption]}");
+        await sourceHandle.WaitForAsync();
+        await targetHandle.WaitForAsync();
+
+        // The attachments section sits near the bottom of the long edit page — below the 1280x720
+        // viewport fold. Raw Mouse.Move addresses viewport coordinates and does not auto-scroll, so
+        // the handles must be scrolled into view first or the pointer never hovers the target.
+        await sourceHandle.ScrollIntoViewIfNeededAsync();
+        await targetHandle.ScrollIntoViewIfNeededAsync();
+
+        var sourceBox = await sourceHandle.BoundingBoxAsync()
+            ?? throw new Exception("Source drag handle has no bounding box.");
+        var targetBox = await targetHandle.BoundingBoxAsync()
+            ?? throw new Exception("Target drag handle has no bounding box.");
+
+        var sx = (float)(sourceBox.X + sourceBox.Width / 2);
+        var sy = (float)(sourceBox.Y + sourceBox.Height / 2);
+        var tx = (float)(targetBox.X + targetBox.Width / 2);
+        var ty = (float)(targetBox.Y + targetBox.Height / 2);
+
+        // handleDragEnd fires the reorder PATCH on mouse-up; register the wait before releasing.
+        var responseTask = ctx.Page.WaitForResponseAsync(r =>
+            r.Url.Contains("/attachments/")
+            && r.Url.Contains("/reorder")
+            && r.Request.Method == "PATCH");
+
+        // dnd-kit's collision detection runs per pointer-move against droppable rects that are only
+        // measured after the activation triggers an onDragStart re-render. Mouse.Move(Steps=N) emits
+        // its sub-moves back-to-back with no scheduler gap, so they can all land before that render
+        // commits — collision finds no droppable, `over` stays null, and mouse-up yields no reorder
+        // (a hard 30s flake). The fix, verified against the live SPA, is to space the moves out with
+        // a real pause between each so dnd-kit's RAF-driven measurement runs between them.
+        await ctx.Page.Mouse.MoveAsync(sx, sy);
+        await ctx.Page.Mouse.DownAsync();
+        await ctx.Page.Mouse.MoveAsync(sx, sy + 12); // cross the 8px activation distance
+        await ctx.Page.WaitForTimeoutAsync(100); // let onDragStart commit + measure droppables
+
+        const int steps = 10;
+        for (var i = 1; i <= steps; i++)
+        {
+            var mx = sx + (tx - sx) * i / steps;
+            var my = (sy + 12) + (ty - (sy + 12)) * i / steps;
+            await ctx.Page.Mouse.MoveAsync(mx, my);
+            await ctx.Page.WaitForTimeoutAsync(20);
+        }
+
+        await ctx.Page.Mouse.MoveAsync(tx, ty);
+        await ctx.Page.WaitForTimeoutAsync(100); // let the final over-target collision settle
+        await ctx.Page.Mouse.UpAsync();
+        await responseTask;
+    }
+
+    // ---- Delete ----
+
+    [When("I delete the attachment captioned {string}")]
+    public async Task WhenIDeleteTheAttachment(string caption)
+    {
+        var id = ctx.RecipeAttachmentIds[caption];
+        var responseTask = ctx.Page.WaitForResponseAsync(r =>
+            r.Url.Contains($"/attachments/{id}")
+            && r.Request.Method == "DELETE"
+            && r.Status == 204);
+        await ctx.Page.GetByTestId($"recipe-attachment-{id}-delete").ClickAsync();
+        await responseTask;
+    }
+
+    // ---- View page interactions ----
+
+    [When("I open the attachment tile captioned {string}")]
+    public async Task WhenIOpenTheAttachmentTile(string caption)
+    {
+        var id = ctx.RecipeAttachmentIds[caption];
+        await ctx.Page.GetByTestId($"recipe-attachment-{id}").ClickAsync();
+    }
+
+    // ---- Assertions ----
+
+    [Then("the attachments list shows an attachment captioned {string}")]
+    public async Task ThenTheAttachmentsListShowsCaptioned(string caption)
+    {
+        // Match the caption by its (user-entered, non-translated) text within the section's caption
+        // labels, so this works for both freshly-uploaded and edited attachments without an id.
+        await Assertions.Expect(
+            ctx.Page.GetByTestId("recipe-section-attachments-content")
+                .Locator("[data-testid$='-caption']")
+                .Filter(new LocatorFilterOptions { HasText = caption })).ToBeVisibleAsync();
+    }
+
+    [Then("the first attachment is captioned {string}")]
+    public async Task ThenTheFirstAttachmentIsCaptioned(string caption)
+    {
+        var firstCaption = ctx.Page.GetByTestId("recipe-section-attachments-content")
+            .Locator("[data-testid$='-caption']").First;
+        await Assertions.Expect(firstCaption).ToContainTextAsync(caption);
+    }
+
+    [Then("the attachment captioned {string} is no longer listed")]
+    public async Task ThenTheAttachmentIsNoLongerListed(string caption)
+    {
+        var id = ctx.RecipeAttachmentIds[caption];
+        await Assertions.Expect(ctx.Page.GetByTestId($"recipe-attachment-row-{id}")).Not.ToBeVisibleAsync();
+    }
+
+    [Then("the attachment tile captioned {string} is shown")]
+    public async Task ThenTheAttachmentTileIsShown(string caption)
+    {
+        var id = ctx.RecipeAttachmentIds[caption];
+        await Assertions.Expect(ctx.Page.GetByTestId("recipe-view-attachments")).ToBeVisibleAsync();
+        await Assertions.Expect(ctx.Page.GetByTestId($"recipe-attachment-{id}")).ToBeVisibleAsync();
+    }
+
+    [Then("the attachment lightbox shows the full-resolution image")]
+    public async Task ThenTheLightboxShowsTheImage()
+    {
+        await Assertions.Expect(ctx.Page.GetByTestId("recipe-attachment-lightbox")).ToBeVisibleAsync();
+
+        // A revoked/broken object URL still renders a "visible" <img>, so assert the image actually
+        // decoded (complete && naturalWidth > 0) — this confirms the /file endpoint served real bytes.
+        var img = ctx.Page.GetByTestId("recipe-attachment-lightbox").Locator("img");
+        await img.WaitForAsync();
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        var loaded = false;
+        while (DateTime.UtcNow < deadline)
+        {
+            loaded = await img.EvaluateAsync<bool>("el => el.complete && el.naturalWidth > 0");
+            if (loaded)
+            {
+                break;
+            }
+
+            await Task.Delay(200);
+        }
+
+        Assert.True(loaded, "Lightbox <img> did not finish loading (complete && naturalWidth > 0).");
+    }
+}

--- a/Application/Frigorino.IntegrationTests/Slices/Recipes/RecipeAttachments.feature
+++ b/Application/Frigorino.IntegrationTests/Slices/Recipes/RecipeAttachments.feature
@@ -1,0 +1,48 @@
+Feature: Recipe attachments
+
+  Background:
+    Given I am logged in with an active household
+
+  Scenario: User attaches an image to a recipe and views it in the lightbox
+    Given there is a recipe named "Pasta Carbonara"
+    When I open the recipe "Pasta Carbonara" for editing
+    And I expand the attachments section
+    And I attach an image with caption "Finished dish"
+    Then the attachments list shows an attachment captioned "Finished dish"
+    When I open the recipe "Pasta Carbonara"
+    And I open the attachment tile captioned "Finished dish"
+    Then the attachment lightbox shows the full-resolution image
+
+  Scenario: User attaches a PDF document to a recipe
+    Given there is a recipe named "Pasta Carbonara"
+    When I open the recipe "Pasta Carbonara" for editing
+    And I expand the attachments section
+    And I attach a document with caption "Recipe sheet"
+    Then the attachments list shows an attachment captioned "Recipe sheet"
+    When I open the recipe "Pasta Carbonara"
+    Then the attachment tile captioned "Recipe sheet" is shown
+
+  Scenario: User edits an attachment caption
+    Given there is a recipe named "Pasta Carbonara"
+    And the recipe "Pasta Carbonara" has an image attachment captioned "Old caption"
+    When I open the recipe "Pasta Carbonara" for editing
+    And I expand the attachments section
+    And I edit the attachment captioned "Old caption" to "New caption"
+    Then the attachments list shows an attachment captioned "New caption"
+
+  Scenario: User reorders attachments by dragging
+    Given there is a recipe named "Pasta Carbonara"
+    And the recipe "Pasta Carbonara" has an image attachment captioned "First"
+    And the recipe "Pasta Carbonara" has an image attachment captioned "Second"
+    When I open the recipe "Pasta Carbonara" for editing
+    And I expand the attachments section
+    And I drag the attachment captioned "Second" above "First"
+    Then the first attachment is captioned "Second"
+
+  Scenario: User deletes an attachment
+    Given there is a recipe named "Pasta Carbonara"
+    And the recipe "Pasta Carbonara" has an image attachment captioned "To delete"
+    When I open the recipe "Pasta Carbonara" for editing
+    And I expand the attachments section
+    And I delete the attachment captioned "To delete"
+    Then the attachment captioned "To delete" is no longer listed

--- a/IDEAS_Recipes.md
+++ b/IDEAS_Recipes.md
@@ -16,10 +16,6 @@ Same intent as `IDEAS.md` (forward-looking enhancements), scoped to recipes. Eac
 - **Why:** Filter recipes by course — Entry / Main / Side / Salad / Dessert / Breakfast / Drink / Snack… Client requirement #3.
 - **Sketch:** Fixed curated **multi-select enum**, stored as flat `RecipeTag` join rows (`RecipeId`, `Tag`), serialized as string names like other enums. Tag-filter chips on the recipes overview. (Free-form household tags considered and set aside in favor of the curated set — revisit only if the fixed list proves limiting.)
 
-## Attachment-flow integration tests (deferred debt)
-
-- **Why:** Both the image-attachments phase (PR #126) and the document-attachments phase shipped covered by unit tests + manual verification only — dedicated Reqnroll/Playwright IT scenarios for the attachment flow (upload, caption edit, reorder, delete/undo, view-page open) were deferred. Tracked here so the gap isn't forgotten.
-
 ## AI-generated cooking instructions from sources
 
 - **Why:** Client requirement #5's end-goal — once a recipe has source material (link/document), use AI to extract in-app cooking instructions, turning the MVP "ingredient list" into a full recipe.


### PR DESCRIPTION
## What

Reqnroll/Playwright integration tests for the recipe attachment flow — the deferred debt tracked in `IDEAS_Recipes.md` (image-attachments PR #126 + the document-attachments phase shipped with unit tests + manual verification only).

## Scenarios (`RecipeAttachments.feature`)

- **Image upload → lightbox view** — uploads via the UI, asserts the row appears, then opens the view-page tile and verifies the full-res image actually decodes (`complete && naturalWidth > 0`).
- **PDF document upload → view tile** — uploads a document, asserts the edit-list row and the view-page tile.
- **Caption edit** — opens the caption sheet on a seeded attachment, saves a new caption, asserts the displayed caption updates.
- **Drag reorder** — real dnd-kit drag, awaits the `/reorder` PATCH, asserts the new order.
- **Delete** — deletes a row, asserts it's gone.

## Notes

- **Undo intentionally omitted** — same sonner auto-dismiss timing flake that the lists/inventory undo-toast scenarios are `@ignore`'d for. Delete is covered; restore is left out by design.
- The reorder drag needed two robustness measures beyond the existing list drag step, both found by reproducing live on the dev stack:
  1. **Scroll the handles into view** — the attachments section sits below the 1280×720 headless viewport fold on the long edit page; raw `Mouse.Move` doesn't auto-scroll.
  2. **Space out the pointer moves** — `Mouse.Move(Steps=N)` fires sub-moves back-to-back before dnd-kit's `onDragStart` measures droppables, so `over` stays null and no PATCH fires. An explicit move-then-wait loop fixes it.
- Helpers added to `TestApiClient` (image/document upload + byte-serving) and `ScenarioContextHolder` (caption→id map).

## Verification

New feature run green **3/3** repeated runs (5/5 scenarios, ~14s each), no timeouts.